### PR TITLE
# Gradient-Aware Upscaling & SnugBox AABB for gsplat2d (+ optional Cholesky and Opacities)

### DIFF
--- a/gaussianlig.py
+++ b/gaussianlig.py
@@ -70,7 +70,7 @@ class Gaussian2D(nn.Module):
     def forward(self):
         (
             xys,
-            radii,
+            extents,
             conics,
             num_tiles_hit,
         ) = project_gaussians(
@@ -82,7 +82,7 @@ class Gaussian2D(nn.Module):
         )
         out_img = rasterize_gaussians(
                 xys,
-                radii,
+                extents,
                 conics,
                 num_tiles_hit,
                 self.rgbs,
@@ -90,7 +90,7 @@ class Gaussian2D(nn.Module):
                 self.H,
                 self.W,
                 self.B_SIZE,
-            )[..., :3]
+            )[0][..., :3]
 
         out_img = torch.clamp(out_img, 0, 1)
         out_img = out_img.view(-1, self.H, self.W, 3).permute(0, 3, 1, 2).contiguous()

--- a/gaussianlig.py
+++ b/gaussianlig.py
@@ -86,6 +86,7 @@ class Gaussian2D(nn.Module):
                 conics,
                 num_tiles_hit,
                 self.rgbs,
+                None,
                 self.H,
                 self.W,
                 self.B_SIZE,

--- a/gsplat2d/gsplat2d/__init__.py
+++ b/gsplat2d/gsplat2d/__init__.py
@@ -2,6 +2,7 @@ from typing import Any
 import torch
 from .project_gaussians import project_gaussians
 from .rasterize import rasterize_gaussians
+from .upscale import gradient_aware_upscale
 from .utils import (
     map_gaussian_to_intersects,
     bin_and_sort_gaussians,
@@ -22,6 +23,7 @@ __all__ = [
     "compute_cov2d_bounds",
     "get_tile_bin_edges",
     "map_gaussian_to_intersects",
+    "gradient_aware_upscale",
     "ProjectGaussians",
     "RasterizeGaussians",
     "BinAndSortGaussians",

--- a/gsplat2d/gsplat2d/__init__.py
+++ b/gsplat2d/gsplat2d/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any
 import torch
 from .project_gaussians import project_gaussians
+from .project_gaussians_cholesky import project_gaussians_cholesky
 from .rasterize import rasterize_gaussians
 from .upscale import gradient_aware_upscale
 from .utils import (
@@ -18,6 +19,7 @@ __all__ = [
     "__version__",
     "project_gaussians",
     "rasterize_gaussians",
+    "project_gaussians_cholesky",
     "bin_and_sort_gaussians",
     "compute_cumulative_intersects",
     "compute_cov2d_bounds",

--- a/gsplat2d/gsplat2d/cuda/__init__.py
+++ b/gsplat2d/gsplat2d/cuda/__init__.py
@@ -18,3 +18,6 @@ project_gaussians_forward = _make_lazy_cuda_func("project_gaussians_forward")
 project_gaussians_backward = _make_lazy_cuda_func("project_gaussians_backward")
 map_gaussian_to_intersects = _make_lazy_cuda_func("map_gaussian_to_intersects")
 get_tile_bin_edges = _make_lazy_cuda_func("get_tile_bin_edges")
+
+gradient_aware_upscale_forward = _make_lazy_cuda_func("gradient_aware_upscale_forward")
+gradient_aware_upscale_backward = _make_lazy_cuda_func("gradient_aware_upscale_backward")

--- a/gsplat2d/gsplat2d/cuda/__init__.py
+++ b/gsplat2d/gsplat2d/cuda/__init__.py
@@ -19,5 +19,8 @@ project_gaussians_backward = _make_lazy_cuda_func("project_gaussians_backward")
 map_gaussian_to_intersects = _make_lazy_cuda_func("map_gaussian_to_intersects")
 get_tile_bin_edges = _make_lazy_cuda_func("get_tile_bin_edges")
 
+project_gaussians_forward_cholesky = _make_lazy_cuda_func("project_gaussians_forward_cholesky")
+project_gaussians_backward_cholesky = _make_lazy_cuda_func("project_gaussians_backward_cholesky")
+
 gradient_aware_upscale_forward = _make_lazy_cuda_func("gradient_aware_upscale_forward")
 gradient_aware_upscale_backward = _make_lazy_cuda_func("gradient_aware_upscale_backward")

--- a/gsplat2d/gsplat2d/cuda/csrc/CMakeLists.txt
+++ b/gsplat2d/gsplat2d/cuda/csrc/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(gsplat2d
     forward.cu
     backward.cu
     bindings.cu
+    gradient_aware_rasterizer.cu
+    gradient_aware_upscaler.cu
     ext.cpp
 )
 target_link_libraries(gsplat2d PUBLIC cuda)

--- a/gsplat2d/gsplat2d/cuda/csrc/CMakeLists.txt
+++ b/gsplat2d/gsplat2d/cuda/csrc/CMakeLists.txt
@@ -9,7 +9,12 @@ set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 # our library library
-add_library(gsplat2d forward.cu backward.cu helpers.cuh)
+add_library(gsplat2d
+    forward.cu
+    backward.cu
+    bindings.cu
+    ext.cpp
+)
 target_link_libraries(gsplat2d PUBLIC cuda)
 target_include_directories(gsplat2d PRIVATE
     ${PROJECT_SOURCE_DIR}/third_party/glm

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cu
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cu
@@ -171,7 +171,7 @@ __global__ void rasterize_backward_kernel(
 
 __global__ void project_gaussians_backward_kernel(
     const int num_points,
-    const int* __restrict__ radii,
+    const float2* __restrict__ extents,
     const float3* __restrict__ conics,
     const float2* __restrict__ v_xy,
     const float3* __restrict__ v_conic,
@@ -179,7 +179,7 @@ __global__ void project_gaussians_backward_kernel(
     float2* __restrict__ v_mean2d
 ) {
     unsigned idx = cg::this_grid().thread_rank(); // idx of thread within grid
-    if (idx >= num_points || radii[idx] <= 0) {
+    if (idx >= num_points || (extents[idx].x <= 0.f || extents[idx].y <= 0.f)) {
         return;
     }
 
@@ -192,7 +192,7 @@ __global__ void project_gaussians_backward_kernel(
 
 __global__ void project_gaussians_backward_kernel_cholesky(
     const int num_points,
-    const int* __restrict__ radii,
+    const float2* __restrict__ extents,
     const float3* __restrict__ cholesky,
     const float3* __restrict__ conics,
     const float2* __restrict__ v_xy,
@@ -201,7 +201,7 @@ __global__ void project_gaussians_backward_kernel_cholesky(
     float2* __restrict__ v_mean2d
 ) {
     unsigned idx = cg::this_grid().thread_rank();
-    if (idx >= num_points || radii[idx] <= 0) {
+    if (idx >= num_points || (extents[idx].x <= 0.f || extents[idx].y <= 0.f)) {
         return;
     }
 

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cu
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cu
@@ -5,21 +5,6 @@
 #include <cooperative_groups/reduce.h>
 namespace cg = cooperative_groups;
 
-inline __device__ void warpSum3(float3& val, cg::thread_block_tile<32>& tile){
-    val.x = cg::reduce(tile, val.x, cg::plus<float>());
-    val.y = cg::reduce(tile, val.y, cg::plus<float>());
-    val.z = cg::reduce(tile, val.z, cg::plus<float>());
-}
-
-inline __device__ void warpSum2(float2& val, cg::thread_block_tile<32>& tile){
-    val.x = cg::reduce(tile, val.x, cg::plus<float>());
-    val.y = cg::reduce(tile, val.y, cg::plus<float>());
-}
-
-inline __device__ void warpSum(float& val, cg::thread_block_tile<32>& tile){
-    val = cg::reduce(tile, val, cg::plus<float>());
-}
-
 __global__ void rasterize_backward_kernel(
     const dim3 tile_bounds,
     const dim3 img_size,

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
@@ -31,3 +31,25 @@ __global__ void rasterize_backward_kernel(
     float3* __restrict__ v_cov,
     float3* __restrict__ v_rgb
 );
+
+__global__ void gradient_aware_rasterize_backward_kernel(
+    const dim3 tile_bounds,
+    const dim3 img_size,
+    const int32_t* __restrict__ gaussian_ids_sorted,
+    const int2* __restrict__ tile_bins,
+    const float2* __restrict__ xys,
+    const float3* __restrict__ conics,
+    const float3* __restrict__ rgbs,
+    const float* __restrict__ opacities,
+    const int* __restrict__ final_index,
+    const float3* __restrict__ v_output,
+    const float3* __restrict__ v_output_dx,
+    const float3* __restrict__ v_output_dy,
+    const float3* __restrict__ v_output_dxy,
+    const float* __restrict__ v_output_wsum,
+    float2* __restrict__ v_xy,
+    float2* __restrict__ v_xy_abs,
+    float3* __restrict__ v_conic,
+    float3* __restrict__ v_rgb,
+    float* __restrict__ v_opacity
+);

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
@@ -23,13 +23,15 @@ __global__ void rasterize_backward_kernel(
     const float2* __restrict__ xys,
     const float3* __restrict__ conics,
     const float3* __restrict__ rgbs,
+    const float* __restrict__ opacities,
     const int* __restrict__ final_index,
     const float3* __restrict__ v_output,
     const float* __restrict__ v_render_wsum,
     float2* __restrict__ v_xy,
     float2* __restrict__ v_xy_abs,
     float3* __restrict__ v_cov,
-    float3* __restrict__ v_rgb
+    float3* __restrict__ v_rgb,
+    float* __restrict__ v_opacity
 );
 
 __global__ void gradient_aware_rasterize_backward_kernel(

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
@@ -53,3 +53,14 @@ __global__ void gradient_aware_rasterize_backward_kernel(
     float3* __restrict__ v_rgb,
     float* __restrict__ v_opacity
 );
+
+__global__ void project_gaussians_backward_kernel_cholesky(
+    const int num_points,
+    const int* __restrict__ radii,
+    const float3* __restrict__ cholesky,
+    const float3* __restrict__ conics,
+    const float2* __restrict__ v_xy,
+    const float3* __restrict__ v_conic,
+    float3* __restrict__ v_cholesky,
+    float2* __restrict__ v_mean2d
+);

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
@@ -25,6 +25,7 @@ __global__ void rasterize_backward_kernel(
     const float3* __restrict__ rgbs,
     const int* __restrict__ final_index,
     const float3* __restrict__ v_output,
+    const float* __restrict__ v_render_wsum,
     float2* __restrict__ v_xy,
     float2* __restrict__ v_xy_abs,
     float3* __restrict__ v_cov,

--- a/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/backward.cuh
@@ -7,7 +7,7 @@
 // compute vjp i.e. vT J -> R(n)
 __global__ void project_gaussians_backward_kernel(
     const int num_points,
-    const int* __restrict__ radii,
+    const float2* __restrict__ extents,
     const float3* __restrict__ conics,
     const float2* __restrict__ v_xy,
     const float3* __restrict__ v_conic,
@@ -56,7 +56,7 @@ __global__ void gradient_aware_rasterize_backward_kernel(
 
 __global__ void project_gaussians_backward_kernel_cholesky(
     const int num_points,
-    const int* __restrict__ radii,
+    const float2* __restrict__ extents,
     const float3* __restrict__ cholesky,
     const float3* __restrict__ conics,
     const float2* __restrict__ v_xy,

--- a/gsplat2d/gsplat2d/cuda/csrc/bindings.h
+++ b/gsplat2d/gsplat2d/cuda/csrc/bindings.h
@@ -108,6 +108,7 @@ std::tuple<
     const torch::Tensor &xys,
     const torch::Tensor &conics,
     const torch::Tensor &colors,
+    const c10::optional<torch::Tensor> &opacities,
     bool compute_upscale_gradients = true
 );
 
@@ -116,7 +117,8 @@ std::
         torch::Tensor, // dL_dxy
         torch::Tensor, // dL_dxy_abs
         torch::Tensor, // dL_dconic
-        torch::Tensor // dL_dcolors
+        torch::Tensor, // dL_dcolors
+        torch::Tensor  // dL_dopacities (optional, empty if opacities not provided)
         >
     rasterize_backward_tensor(
         const unsigned img_height,
@@ -130,6 +132,7 @@ std::
         const torch::Tensor &final_idx,
         const torch::Tensor &v_output,
         const torch::Tensor &v_render_wsum,
+        const c10::optional<torch::Tensor> &opacities,
         const c10::optional<torch::Tensor> &v_output_dx,
         const c10::optional<torch::Tensor> &v_output_dy,
         const c10::optional<torch::Tensor> &v_output_dxy

--- a/gsplat2d/gsplat2d/cuda/csrc/bindings.h
+++ b/gsplat2d/gsplat2d/cuda/csrc/bindings.h
@@ -18,8 +18,11 @@
 
 std::tuple<
     torch::Tensor, // output conics
-    torch::Tensor> // output radii
-compute_cov2d_bounds_tensor(const int num_pts, torch::Tensor &A);
+    torch::Tensor> // output extent
+compute_cov2d_bounds_tensor(
+    const int num_pts,
+    torch::Tensor &A,
+    const c10::optional<torch::Tensor> &opacities);
 
 std::tuple<
     torch::Tensor,
@@ -30,6 +33,7 @@ project_gaussians_forward_tensor(
     const int num_points,
     torch::Tensor &cov2d,
     torch::Tensor &means2d,
+    const c10::optional<torch::Tensor> &opacities,
     const unsigned img_height,
     const unsigned img_width,
     const unsigned block_width
@@ -40,7 +44,7 @@ std::tuple<
     torch::Tensor>
 project_gaussians_backward_tensor(
     const int num_points,
-    torch::Tensor &radii,
+    torch::Tensor &extent,
     torch::Tensor &conics,
     torch::Tensor &v_xy,
     torch::Tensor &v_conic
@@ -55,6 +59,7 @@ project_gaussians_forward_cholesky_tensor(
     const int num_points,
     torch::Tensor &cholesky,
     torch::Tensor &means2d,
+    const c10::optional<torch::Tensor> &opacities,
     const unsigned img_height,
     const unsigned img_width,
     const unsigned block_width
@@ -63,7 +68,7 @@ project_gaussians_forward_cholesky_tensor(
 std::tuple<torch::Tensor, torch::Tensor>
 project_gaussians_backward_cholesky_tensor(
     const int num_points,
-    torch::Tensor &radii,
+    torch::Tensor &extent,
     torch::Tensor &cholesky,
     torch::Tensor &conics,
     torch::Tensor &v_xy,
@@ -75,7 +80,7 @@ std::tuple<torch::Tensor, torch::Tensor> map_gaussian_to_intersects_tensor(
     const int num_intersects,
     const torch::Tensor &xys,
     const torch::Tensor &depths,
-    const torch::Tensor &radii,
+    const torch::Tensor &extent,
     const torch::Tensor &cum_tiles_hit,
     const std::tuple<int, int, int> tile_bounds,
     const unsigned block_width

--- a/gsplat2d/gsplat2d/cuda/csrc/bindings.h
+++ b/gsplat2d/gsplat2d/cuda/csrc/bindings.h
@@ -65,8 +65,9 @@ torch::Tensor get_tile_bin_edges_tensor(
 );
 
 std::tuple<
-    torch::Tensor,
-    torch::Tensor
+    torch::Tensor, // output img
+    torch::Tensor, // output wsum
+    torch::Tensor // output final_idx
 > rasterize_forward_tensor(
     const std::tuple<int, int, int> tile_bounds,
     const std::tuple<int, int, int> block,
@@ -95,5 +96,6 @@ std::
         const torch::Tensor &conics,
         const torch::Tensor &colors,
         const torch::Tensor &final_idx,
-        const torch::Tensor &v_output
+        const torch::Tensor &v_output,
+        const torch::Tensor &v_render_wsum
     );

--- a/gsplat2d/gsplat2d/cuda/csrc/bindings.h
+++ b/gsplat2d/gsplat2d/cuda/csrc/bindings.h
@@ -67,6 +67,9 @@ torch::Tensor get_tile_bin_edges_tensor(
 std::tuple<
     torch::Tensor, // output img
     torch::Tensor, // output wsum
+    torch::Tensor, // output dx
+    torch::Tensor, // output dy
+    torch::Tensor, // output dxy
     torch::Tensor // output final_idx
 > rasterize_forward_tensor(
     const std::tuple<int, int, int> tile_bounds,
@@ -76,7 +79,8 @@ std::tuple<
     const torch::Tensor &tile_bins,
     const torch::Tensor &xys,
     const torch::Tensor &conics,
-    const torch::Tensor &colors
+    const torch::Tensor &colors,
+    bool compute_upscale_gradients = true
 );
 
 std::
@@ -97,5 +101,29 @@ std::
         const torch::Tensor &colors,
         const torch::Tensor &final_idx,
         const torch::Tensor &v_output,
-        const torch::Tensor &v_render_wsum
+        const torch::Tensor &v_render_wsum,
+        const c10::optional<torch::Tensor> &v_output_dx,
+        const c10::optional<torch::Tensor> &v_output_dy,
+        const c10::optional<torch::Tensor> &v_output_dxy
     );
+torch::Tensor gradient_aware_upscale_forward_tensor(
+    const torch::Tensor &render,    // [H, W, 3]
+    const torch::Tensor &dx,
+    const torch::Tensor &dy,
+    const torch::Tensor &dxy,
+    int dst_h,
+    int dst_w,
+    const std::tuple<float, float, float, float> &roi  // x1, y1, x2, y2
+);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+gradient_aware_upscale_backward_tensor(
+    const torch::Tensor &grad_output,  // [dst_h, dst_w, 3]
+    const torch::Tensor &render,       // [H, W, 3]
+    const torch::Tensor &dx,
+    const torch::Tensor &dy,
+    const torch::Tensor &dxy,
+    int dst_h,
+    int dst_w,
+    const std::tuple<float, float, float, float> &roi
+);

--- a/gsplat2d/gsplat2d/cuda/csrc/bindings.h
+++ b/gsplat2d/gsplat2d/cuda/csrc/bindings.h
@@ -46,6 +46,29 @@ project_gaussians_backward_tensor(
     torch::Tensor &v_conic
 );
 
+std::tuple<
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor>
+project_gaussians_forward_cholesky_tensor(
+    const int num_points,
+    torch::Tensor &cholesky,
+    torch::Tensor &means2d,
+    const unsigned img_height,
+    const unsigned img_width,
+    const unsigned block_width
+);
+
+std::tuple<torch::Tensor, torch::Tensor>
+project_gaussians_backward_cholesky_tensor(
+    const int num_points,
+    torch::Tensor &radii,
+    torch::Tensor &cholesky,
+    torch::Tensor &conics,
+    torch::Tensor &v_xy,
+    torch::Tensor &v_conic
+);
 
 std::tuple<torch::Tensor, torch::Tensor> map_gaussian_to_intersects_tensor(
     const int num_points,

--- a/gsplat2d/gsplat2d/cuda/csrc/ext.cpp
+++ b/gsplat2d/gsplat2d/cuda/csrc/ext.cpp
@@ -10,4 +10,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("compute_cov2d_bounds", &compute_cov2d_bounds_tensor);
     m.def("map_gaussian_to_intersects", &map_gaussian_to_intersects_tensor);
     m.def("get_tile_bin_edges", &get_tile_bin_edges_tensor);
+
+    m.def("gradient_aware_upscale_forward", &gradient_aware_upscale_forward_tensor);
+    m.def("gradient_aware_upscale_backward", &gradient_aware_upscale_backward_tensor);
 }

--- a/gsplat2d/gsplat2d/cuda/csrc/ext.cpp
+++ b/gsplat2d/gsplat2d/cuda/csrc/ext.cpp
@@ -6,6 +6,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("rasterize_backward", &rasterize_backward_tensor);
     m.def("project_gaussians_forward", &project_gaussians_forward_tensor);
     m.def("project_gaussians_backward", &project_gaussians_backward_tensor);
+    m.def("project_gaussians_forward_cholesky", &project_gaussians_forward_cholesky_tensor);
+    m.def("project_gaussians_backward_cholesky", &project_gaussians_backward_cholesky_tensor);
     
     m.def("compute_cov2d_bounds", &compute_cov2d_bounds_tensor);
     m.def("map_gaussian_to_intersects", &map_gaussian_to_intersects_tensor);

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cu
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cu
@@ -201,11 +201,8 @@ __global__ void rasterize_forward(
 
 
             int32_t g = id_batch[t];
-            const float vis = alpha;
             const float3 c = colors[g];
-            pix_out.x = pix_out.x + c.x * vis;
-            pix_out.y = pix_out.y + c.y * vis;
-            pix_out.z = pix_out.z + c.z * vis;
+            pix_out += c * alpha;
             cur_idx = batch_start + t;
         }
     }
@@ -213,11 +210,6 @@ __global__ void rasterize_forward(
     if (inside) {
         final_index[pix_id] =
             cur_idx; // index of in bin of last gaussian in this pixel
-        float3 final_color;
-
-        final_color.x = pix_out.x;
-        final_color.y = pix_out.y;
-        final_color.z = pix_out.z;
-        out_img[pix_id] = final_color;
+        out_img[pix_id] = pix_out;
     }
 }

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
@@ -43,15 +43,3 @@ __global__ void map_gaussian_to_intersects(
 __global__ void get_tile_bin_edges(
     const int num_intersects, const int64_t* __restrict__ isect_ids_sorted, int2* __restrict__ tile_bins
 );
-
-__global__ void rasterize_forward(
-    const dim3 tile_bounds,
-    const dim3 img_size,
-    const int32_t* __restrict__ gaussian_ids_sorted,
-    const int2* __restrict__ tile_bins,
-    const float2* __restrict__ xys,
-    const float3* __restrict__ conics,
-    const float3* __restrict__ colors,
-    int* __restrict__ final_index,
-    float3* __restrict__ out_img
-);

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
@@ -7,10 +7,11 @@ __global__ void project_gaussians_forward_kernel(
     const int num_points,
     const float3* __restrict__ cov2d,
     const float2* __restrict__ means2d,
+    const float* __restrict__ opacities,
     const dim3 tile_bounds,
     const unsigned block_width,
     float2* __restrict__ xys,
-    int* __restrict__ radii,
+    float2* __restrict__ extents,
     float3* __restrict__ conics,
     int32_t* __restrict__ num_tiles_hit
 );
@@ -25,7 +26,7 @@ __global__ void project_gaussians_forward_kernel_cholesky(
     const dim3 tile_bounds,
     const unsigned block_width,
     float2* __restrict__ xys,
-    float2* __restrict__ extent,
+    float2* __restrict__ extents,
     float3* __restrict__ conics,
     int32_t* __restrict__ num_tiles_hit
 );
@@ -48,7 +49,7 @@ __global__ void map_gaussian_to_intersects(
     const int num_points,
     const float2* __restrict__ xys,
     const float* __restrict__ depths,
-    const int* __restrict__ radii,
+    const float2* __restrict__ extents,
     const int32_t* __restrict__ cum_tiles_hit,
     const dim3 tile_bounds,
     const unsigned block_width,

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
@@ -25,7 +25,8 @@ __global__ void rasterize_forward(
     const float3* __restrict__ conics,
     const float3* __restrict__ colors,
     int* __restrict__ final_index,
-    float3* __restrict__ out_img
+    float3* __restrict__ out_img,
+    float* __restrict__ out_wsum
 );
 
 __global__ void map_gaussian_to_intersects(

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
@@ -15,6 +15,21 @@ __global__ void project_gaussians_forward_kernel(
     int32_t* __restrict__ num_tiles_hit
 );
 
+
+// project gaussians directly from cholesky decomposition
+__global__ void project_gaussians_forward_kernel_cholesky(
+    const int num_points,
+    const float3* __restrict__ cholesky,  // [l11, l21, l22]
+    const float2* __restrict__ means2d,
+    const float* __restrict__ opacities,
+    const dim3 tile_bounds,
+    const unsigned block_width,
+    float2* __restrict__ xys,
+    float2* __restrict__ extent,
+    float3* __restrict__ conics,
+    int32_t* __restrict__ num_tiles_hit
+);
+
 // compute output color image from binned and sorted gaussians
 __global__ void rasterize_forward(
     const dim3 tile_bounds,

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
@@ -44,3 +44,33 @@ __global__ void map_gaussian_to_intersects(
 __global__ void get_tile_bin_edges(
     const int num_intersects, const int64_t* __restrict__ isect_ids_sorted, int2* __restrict__ tile_bins
 );
+
+__global__ void rasterize_forward(
+    const dim3 tile_bounds,
+    const dim3 img_size,
+    const int32_t* __restrict__ gaussian_ids_sorted,
+    const int2* __restrict__ tile_bins,
+    const float2* __restrict__ xys,
+    const float3* __restrict__ conics,
+    const float3* __restrict__ colors,
+    int* __restrict__ final_index,
+    float3* __restrict__ out_img
+);
+
+// compute output color image from binned and sorted gaussians
+__global__ void gradient_aware_rasterize_forward(
+    const dim3 tile_bounds,
+    const dim3 img_size,
+    const int32_t* __restrict__ gaussian_ids_sorted,
+    const int2* __restrict__ tile_bins,
+    const float2* __restrict__ xys,
+    const float3* __restrict__ conics,
+    const float3* __restrict__ colors,
+    const float* __restrict__ opacities,  // optional, can be nullptr
+    int* __restrict__ final_index,
+    float3* __restrict__ out_img,
+    float* __restrict__ out_wsum,
+    float3* __restrict__ out_dx,
+    float3* __restrict__ out_dy,
+    float3* __restrict__ out_dxy
+);

--- a/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/forward.cuh
@@ -40,6 +40,7 @@ __global__ void rasterize_forward(
     const float2* __restrict__ xys,
     const float3* __restrict__ conics,
     const float3* __restrict__ colors,
+    const float* __restrict__ opacities,
     int* __restrict__ final_index,
     float3* __restrict__ out_img,
     float* __restrict__ out_wsum
@@ -69,6 +70,7 @@ __global__ void rasterize_forward(
     const float2* __restrict__ xys,
     const float3* __restrict__ conics,
     const float3* __restrict__ colors,
+    const float* __restrict__ opacities,  // optional, can be nullptr
     int* __restrict__ final_index,
     float3* __restrict__ out_img
 );

--- a/gsplat2d/gsplat2d/cuda/csrc/gradient_aware_rasterizer.cu
+++ b/gsplat2d/gsplat2d/cuda/csrc/gradient_aware_rasterizer.cu
@@ -1,0 +1,495 @@
+#include <iostream>
+#include <algorithm>
+#include "forward.cuh"
+#include "backward.cuh"
+#include "helpers.cuh"
+#include <cuda_fp16.h>
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+/**
+ * Backward pass for weighted sum rasterization with gradient-aware upscaling
+ * 
+ * ============================================================================
+ * MATHEMATICAL DERIVATION
+ * ============================================================================
+ * 
+ * Forward outputs (all per-pixel):
+ *   I(x,y)      = Σ c_i * α_i           -- color image
+ *   ∂I/∂x       = Σ c_i * α_x,i         -- image x-gradient  
+ *   ∂I/∂y       = Σ c_i * α_y,i         -- image y-gradient
+ *   ∂²I/∂x∂y    = Σ c_i * α_xy,i        -- mixed partial
+ *   W           = Σ α_i                 -- weight sum
+ * 
+ * where for each gaussian i:
+ *   d = [px - μ_x, py - μ_y]            -- pixel-to-center offset
+ *   σ = 0.5*(a*d_x² + c*d_y²) + b*d_x*d_y   -- quadratic form (conic = {a,b,c})
+ *   α = exp(-σ)                         -- gaussian weight
+ *   
+ *   σ_x = ∂σ/∂x = a*d_x + b*d_y
+ *   σ_y = ∂σ/∂y = b*d_x + c*d_y  
+ *   σ_xy = ∂²σ/∂x∂y = b
+ *   
+ *   α_x  = ∂α/∂x = -α * σ_x
+ *   α_y  = ∂α/∂y = -α * σ_y
+ *   α_xy = ∂²α/∂x∂y = α * (σ_x * σ_y - σ_xy)
+ * 
+ * Incoming gradients from loss (via spline upscaler):
+ *   v_I   = ∂L/∂I
+ *   v_dx  = ∂L/∂(∂I/∂x)
+ *   v_dy  = ∂L/∂(∂I/∂y)
+ *   v_dxy = ∂L/∂(∂²I/∂x∂y)
+ *   v_W   = ∂L/∂W
+ * 
+ * ============================================================================
+ * GRADIENTS W.R.T. COLOR c_k
+ * ============================================================================
+ * 
+ * ∂L/∂c_k = v_I * α_k + v_dx * α_x,k + v_dy * α_y,k + v_dxy * α_xy,k
+ * 
+ * ============================================================================
+ * GRADIENTS W.R.T. GAUSSIAN PARAMETERS (via chain rule through α)
+ * ============================================================================
+ * 
+ * Intermediate "virtual gradients" on α and its derivatives:
+ *   v_α   = dot(v_I, c) + v_W
+ *   v_αx  = dot(v_dx, c)
+ *   v_αy  = dot(v_dy, c)
+ *   v_αxy = dot(v_dxy, c)
+ * 
+ * ============================================================================
+ * GRADIENTS W.R.T. POSITION μ
+ * ============================================================================
+ * 
+ * Note: d = pixel - μ, so ∂d/∂μ = -1
+ * 
+ * ∂α/∂μ_x = α * σ_x           (since ∂σ/∂μ_x = -σ_x)
+ * ∂α/∂μ_y = α * σ_y
+ * 
+ * ∂α_x/∂μ_x = α * (a - σ_x²)
+ * ∂α_x/∂μ_y = α * (b - σ_x * σ_y)
+ * ∂α_y/∂μ_x = α * (b - σ_x * σ_y)
+ * ∂α_y/∂μ_y = α * (c - σ_y²)
+ * 
+ * ∂α_xy/∂μ_x = α * (σ_x² * σ_y - 2*b*σ_x - a*σ_y)
+ * ∂α_xy/∂μ_y = α * (σ_x * σ_y² - 2*b*σ_y - c*σ_x)
+ * 
+ * Total:
+ * ∂L/∂μ_x = v_α * α * σ_x 
+ *         + v_αx * α * (a - σ_x²)
+ *         + v_αy * α * (b - σ_x * σ_y)
+ *         + v_αxy * α * (σ_x² * σ_y - 2*b*σ_x - a*σ_y)
+ * 
+ * ∂L/∂μ_y = v_α * α * σ_y
+ *         + v_αx * α * (b - σ_x * σ_y)
+ *         + v_αy * α * (c - σ_y²)
+ *         + v_αxy * α * (σ_x * σ_y² - 2*b*σ_y - c*σ_x)
+ * 
+ * ============================================================================
+ * GRADIENTS W.R.T. CONIC (inverse covariance) {a, b, c}
+ * ============================================================================
+ * 
+ * ∂σ/∂a = 0.5*d_x²,  ∂σ/∂b = d_x*d_y,  ∂σ/∂c = 0.5*d_y²
+ * ∂σ_x/∂a = d_x,     ∂σ_x/∂b = d_y,    ∂σ_x/∂c = 0
+ * ∂σ_y/∂a = 0,       ∂σ_y/∂b = d_x,    ∂σ_y/∂c = d_y
+ * ∂σ_xy/∂b = 1       (others = 0)
+ * 
+ * ∂α/∂a = -α * 0.5 * d_x²
+ * ∂α/∂b = -α * d_x * d_y
+ * ∂α/∂c = -α * 0.5 * d_y²
+ * 
+ * ∂α_x/∂a = α * (0.5 * d_x² * σ_x - d_x)
+ * ∂α_x/∂b = α * (d_x * d_y * σ_x - d_y)
+ * ∂α_x/∂c = α * (0.5 * d_y² * σ_x)
+ * 
+ * ∂α_y/∂a = α * (0.5 * d_x² * σ_y)
+ * ∂α_y/∂b = α * (d_x * d_y * σ_y - d_x)
+ * ∂α_y/∂c = α * (0.5 * d_y² * σ_y - d_y)
+ * 
+ * Let P = σ_x * σ_y - b (the term in α_xy = α * P)
+ * ∂α_xy/∂a = α * (-0.5 * d_x² * P + d_x * σ_y)
+ * ∂α_xy/∂b = α * (-d_x * d_y * P + d_y * σ_y + d_x * σ_x - 1)
+ * ∂α_xy/∂c = α * (-0.5 * d_y² * P + d_y * σ_x)
+ * 
+ * Total for each conic component combines all four gradient paths.
+ */
+
+__global__ void gradient_aware_rasterize_backward_kernel(
+    const dim3 tile_bounds,
+    const dim3 img_size,
+    const int32_t* __restrict__ gaussian_ids_sorted,
+    const int2* __restrict__ tile_bins,
+    const float2* __restrict__ xys,
+    const float3* __restrict__ conics,
+    const float3* __restrict__ rgbs,
+    const float* __restrict__ opacities,
+    const int* __restrict__ final_index,
+    // Incoming gradients from loss (5 channels)
+    const float3* __restrict__ v_output,      // ∂L/∂I
+    const float3* __restrict__ v_output_dx,   // ∂L/∂(∂I/∂x)
+    const float3* __restrict__ v_output_dy,   // ∂L/∂(∂I/∂y)
+    const float3* __restrict__ v_output_dxy,  // ∂L/∂(∂²I/∂x∂y)
+    const float* __restrict__ v_output_wsum,  // ∂L/∂W
+    // Output gradients w.r.t. gaussian parameters
+    float2* __restrict__ v_xy,
+    float2* __restrict__ v_xy_abs,
+    float3* __restrict__ v_conic,
+    float3* __restrict__ v_rgb,
+    float* __restrict__ v_opacity
+) {
+    auto block = cg::this_thread_block();
+    int32_t tile_id = block.group_index().y * tile_bounds.x + block.group_index().x;
+    unsigned i = block.group_index().y * block.group_dim().y + block.thread_index().y;
+    unsigned j = block.group_index().x * block.group_dim().x + block.thread_index().x;
+
+    const float px = (float)j + 0.5f;
+    const float py = (float)i + 0.5f;
+    const int32_t pix_id = min(i * img_size.x + j, img_size.x * img_size.y - 1);
+    const bool inside = (i < img_size.y && j < img_size.x);
+    const int bin_final = inside ? final_index[pix_id] : 0;
+
+    const int2 range = tile_bins[tile_id];
+    const int block_size = block.size();
+    const int num_batches = (range.y - range.x + block_size - 1) / block_size;
+
+    __shared__ int32_t id_batch[MAX_BLOCK_SIZE];
+    __shared__ float2 xy_batch[MAX_BLOCK_SIZE];
+    __shared__ float3 conic_batch[MAX_BLOCK_SIZE];
+    __shared__ float3 rgbs_batch[MAX_BLOCK_SIZE];
+    __shared__ float opacity_batch[MAX_BLOCK_SIZE];
+
+    // Load all incoming gradients for this pixel
+    const float3 v_I   = v_output[pix_id];
+    const float3 v_dx  = v_output_dx[pix_id];
+    const float3 v_dy  = v_output_dy[pix_id];
+    const float3 v_dxy = v_output_dxy[pix_id];
+    const float  v_W   = v_output_wsum[pix_id];
+
+    const int tr = block.thread_rank();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    const int warp_bin_final = cg::reduce(warp, bin_final, cg::greater<int>());
+
+    for (int batch = 0; batch < num_batches; ++batch) {
+        block.sync();
+
+        // Load gaussians back-to-front
+        const int batch_end = range.y - 1 - block_size * batch;
+        const int batch_size = min(block_size, batch_end + 1 - range.x);
+        const int idx = batch_end - tr;
+        
+        if (idx >= range.x) {
+            int32_t g_id = gaussian_ids_sorted[idx];
+            id_batch[tr] = g_id;
+            xy_batch[tr] = xys[g_id];
+            conic_batch[tr] = conics[g_id];
+            rgbs_batch[tr] = rgbs[g_id];
+            opacity_batch[tr] = opacities ? opacities[g_id] : 1.0f;
+        }
+        block.sync();
+
+        for (int t = max(0, batch_end - warp_bin_final); t < batch_size; ++t) {
+            int valid = inside && (batch_end - t <= bin_final);
+            
+            // Gaussian parameters
+            float alpha = 0.f;
+            float vis = 0.f;
+            float2 d = {0.f, 0.f};
+            float3 conic = {0.f, 0.f, 0.f};
+            float sigma_x = 0.f, sigma_y = 0.f;
+            
+            if (valid) {
+                conic = conic_batch[t];
+                const float2 xy = xy_batch[t];
+                d = {px - xy.x, py - xy.y};
+                
+                const float sigma = 0.5f * (conic.x * d.x * d.x + conic.z * d.y * d.y) 
+                                  + conic.y * d.x * d.y;
+                vis = __expf(-sigma);
+                alpha = min(0.999f, opacity_batch[t] * vis);
+                
+                if (sigma < 0.f || alpha < 1.f / 255.f) {
+                    valid = 0;
+                } else {
+                    // First derivatives of sigma (Eq. 37-38 derivatives)
+                    sigma_x = conic.x * d.x + conic.y * d.y;  // ∂σ/∂x
+                    sigma_y = conic.y * d.x + conic.z * d.y;  // ∂σ/∂y
+                }
+            }
+
+            if (!warp.any(valid)) continue;
+
+            // Initialize local gradient accumulators
+            float3 v_rgb_local = {0.f, 0.f, 0.f};
+            float3 v_conic_local = {0.f, 0.f, 0.f};
+            float2 v_xy_local = {0.f, 0.f};
+            float v_opacity_local = 0.f;
+
+            if (valid) {
+                const float3 c = rgbs_batch[t];
+                const float a = conic.x, b = conic.y, cc = conic.z;
+                
+                // Mixed partial: σ_xy = b
+                const float sigma_xy = b;
+                
+                // α derivatives (from forward pass formulas)
+                const float alpha_x  = -alpha * sigma_x;
+                const float alpha_y  = -alpha * sigma_y;
+                const float alpha_xy = alpha * (sigma_x * sigma_y - sigma_xy);
+                
+                // ================================================================
+                // GRADIENT W.R.T. COLOR (Section: Gradients w.r.t. color c_k)
+                // ∂L/∂c = v_I * α + v_dx * α_x + v_dy * α_y + v_dxy * α_xy
+                // ================================================================
+                v_rgb_local.x = v_I.x * alpha + v_dx.x * alpha_x + v_dy.x * alpha_y + v_dxy.x * alpha_xy;
+
+                v_rgb_local.y = v_I.y * alpha + v_dx.y * alpha_x + v_dy.y * alpha_y + v_dxy.y * alpha_xy;
+                v_rgb_local.z = v_I.z * alpha + v_dx.z * alpha_x + v_dy.z * alpha_y + v_dxy.z * alpha_xy;
+                
+                // ================================================================
+                // VIRTUAL GRADIENTS (Section: Gradients w.r.t. gaussian parameters)
+                // ================================================================
+                const float v_alpha = (v_I.x * c.x + v_I.y * c.y + v_I.z * c.z) + v_W;
+                const float v_alpha_x = v_dx.x * c.x + v_dx.y * c.y + v_dx.z * c.z;
+                const float v_alpha_y = v_dy.x * c.x + v_dy.y * c.y + v_dy.z * c.z;
+                const float v_alpha_xy = v_dxy.x * c.x + v_dxy.y * c.y + v_dxy.z * c.z;
+                
+                // ================================================================
+                // GRADIENT W.R.T. POSITION μ (Section: Gradients w.r.t. position)
+                // Note: d = pixel - μ, so gradients w.r.t. μ have opposite sign
+                // ================================================================
+                const float sx = sigma_x, sy = sigma_y;
+                const float sx2 = sx * sx, sy2 = sy * sy;
+                const float sxsy = sx * sy;
+                
+                // ∂L/∂μ_x (note: result negated because d = px - μ)
+                v_xy_local.x = alpha * (
+                    v_alpha * sx
+                    + v_alpha_x * (a - sx2)
+                    + v_alpha_y * (b - sxsy)
+                    + v_alpha_xy * (sx2 * sy - 2.f * b * sx - a * sy)
+                );
+                
+                // ∂L/∂μ_y
+                v_xy_local.y = alpha * (
+                    v_alpha * sy
+                    + v_alpha_x * (b - sxsy)
+                    + v_alpha_y * (cc - sy2)
+                    + v_alpha_xy * (sx * sy2 - 2.f * b * sy - cc * sx)
+                );
+                
+                // ================================================================
+                // GRADIENT W.R.T. CONIC {a, b, c} (Section: Gradients w.r.t. conic)
+                // ================================================================
+                const float dx = d.x, dy = d.y;
+                const float dx2 = dx * dx, dy2 = dy * dy;
+                const float dxdy = dx * dy;
+                const float P = sxsy - b;  // term in α_xy = α * P
+                
+                // ∂L/∂a
+                v_conic_local.x = alpha * (
+                    v_alpha * (-0.5f * dx2)
+                    + v_alpha_x * (0.5f * dx2 * sx - dx)
+                    + v_alpha_y * (0.5f * dx2 * sy)
+                    + v_alpha_xy * (-0.5f * dx2 * P + dx * sy)
+                );
+                
+                // ∂L/∂b
+                v_conic_local.y = alpha * (
+                    v_alpha * (-dxdy)
+                    + v_alpha_x * (dxdy * sx - dy)
+                    + v_alpha_y * (dxdy * sy - dx)
+                    + v_alpha_xy * (-dxdy * P + dy * sy + dx * sx - 1.f)
+                );
+                
+                // ∂L/∂c
+                v_conic_local.z = alpha * (
+                    v_alpha * (-0.5f * dy2)
+                    + v_alpha_x * (0.5f * dy2 * sx)
+                    + v_alpha_y * (0.5f * dy2 * sy - dy)
+                    + v_alpha_xy * (-0.5f * dy2 * P + dy * sx)
+                );
+                
+                // v_opacity = d(alpha)/d(opacity) * v_alpha = vis * v_alpha
+                v_opacity_local = vis * v_alpha;
+            }
+            
+            // Warp-level reduction
+            warpSum3(v_rgb_local, warp);
+            warpSum3(v_conic_local, warp);
+            warpSum2(v_xy_local, warp);
+            warpSum(v_opacity_local, warp);
+            
+            if (warp.thread_rank() == 0) {
+                int32_t g = id_batch[t];
+                float* v_rgb_ptr = (float*)(v_rgb);
+                atomicAdd(v_rgb_ptr + 3*g + 0, v_rgb_local.x);
+                atomicAdd(v_rgb_ptr + 3*g + 1, v_rgb_local.y);
+                atomicAdd(v_rgb_ptr + 3*g + 2, v_rgb_local.z);
+                
+                float* v_conic_ptr = (float*)(v_conic);
+                atomicAdd(v_conic_ptr + 3*g + 0, v_conic_local.x);
+                atomicAdd(v_conic_ptr + 3*g + 1, v_conic_local.y);
+                atomicAdd(v_conic_ptr + 3*g + 2, v_conic_local.z);
+                
+                float* v_xy_ptr = (float*)(v_xy);
+                atomicAdd(v_xy_ptr + 2*g + 0, v_xy_local.x);
+                atomicAdd(v_xy_ptr + 2*g + 1, v_xy_local.y);
+
+                float* v_xy_abs_ptr = (float*)(v_xy_abs);
+                atomicAdd(v_xy_abs_ptr + 2*g + 0, fabsf(v_xy_local.x));
+                atomicAdd(v_xy_abs_ptr + 2*g + 1, fabsf(v_xy_local.y));
+
+                if (v_opacity) {
+                    atomicAdd(v_opacity + g, v_opacity_local);
+                }
+            }
+        }
+    }
+}
+
+__global__ void gradient_aware_rasterize_forward(
+    const dim3 tile_bounds,
+    const dim3 img_size,
+    const int32_t* __restrict__ gaussian_ids_sorted,
+    const int2* __restrict__ tile_bins,
+    const float2* __restrict__ xys,
+    const float3* __restrict__ conics,
+    const float3* __restrict__ colors,
+    const float* __restrict__ opacities,
+    int* __restrict__ final_index,
+    float3* __restrict__ out_img,
+    float* __restrict__ out_wsum,
+    float3* __restrict__ out_dx,
+    float3* __restrict__ out_dy,
+    float3* __restrict__ out_dxy
+) {
+
+    auto block = cg::this_thread_block();
+    int32_t tile_id =
+        block.group_index().y * tile_bounds.x + block.group_index().x;
+    unsigned i =
+        block.group_index().y * block.group_dim().y + block.thread_index().y;
+    unsigned j =
+        block.group_index().x * block.group_dim().x + block.thread_index().x;
+
+    float px = (float)j + 0.5;
+    float py = (float)i + 0.5;
+    int32_t pix_id = i * img_size.x + j;
+
+    // return if out of bounds
+    // keep not rasterizing threads around for reading data
+    bool inside = (i < img_size.y && j < img_size.x);
+    bool done = !inside;
+
+    // have all threads in tile process the same gaussians in batches
+    // first collect gaussians between range.x and range.y in batches
+    // which gaussians to look through in this tile
+    int2 range = tile_bins[tile_id];
+    const int block_size = block.size();
+    int num_batches = (range.y - range.x + block_size - 1) / block_size;
+
+    __shared__ int32_t id_batch[MAX_BLOCK_SIZE];
+    // __shared__ float3 xy_opacity_batch[MAX_BLOCK_SIZE];
+    __shared__ float2 xy_batch[MAX_BLOCK_SIZE];
+    __shared__ float3 conic_batch[MAX_BLOCK_SIZE];
+    __shared__ float opacity_batch[MAX_BLOCK_SIZE];
+
+    int cur_idx = 0;
+
+    // collect and process batches of gaussians
+    // each thread loads one gaussian at a time before rasterizing its
+    // designated pixel
+    int tr = block.thread_rank();
+    float3 pix_out = {0.f, 0.f, 0.f};
+    float3 pix_dx = {0.f, 0.f, 0.f};
+    float3 pix_dy = {0.f, 0.f, 0.f};
+    float3 pix_dxy = {0.f, 0.f, 0.f};
+    float pix_wsum = 0.f;
+    for (int b = 0; b < num_batches; ++b) {
+        // resync all threads before beginning next batch
+        // end early if entire tile is done
+        if (__syncthreads_count(done) >= block_size) {
+            break;
+        }
+
+        // each thread fetch 1 gaussian from front to back
+        // index of gaussian to load
+        int batch_start = range.x + block_size * b;
+        int idx = batch_start + tr;
+        if (idx < range.y) {
+            int32_t g_id = gaussian_ids_sorted[idx];
+            id_batch[tr] = g_id;
+            xy_batch[tr] = xys[g_id];
+            conic_batch[tr] = conics[g_id];
+            opacity_batch[tr] = opacities ? opacities[g_id] : 1.0f;
+        }
+
+        // wait for other threads to collect the gaussians in batch
+        block.sync();
+
+        // process gaussians in the current batch for this pixel
+        int batch_size = min(block_size, range.y - batch_start);
+        for (int t = 0; (t < batch_size) && !done; ++t) {
+            const float3 conic = conic_batch[t];
+            const float2 xy = xy_batch[t];
+            // d = [x - μ_x, y - μ_y] (Eq. 38)
+            const float2 d = {px - xy.x, py - xy.y};
+            const float sigma = 0.5f * (conic.x * d.x * d.x +
+                                        conic.z * d.y * d.y) +
+                                conic.y * d.x * d.y;
+            const float opacity = opacity_batch[t];
+            const float alpha = min(0.999f, opacity * __expf(-sigma));
+            if (sigma < 0.f || alpha < 1.f / 255.f) {
+                continue;
+            }
+
+            // First-order partial derivatives of sigma = -g (Eq. 37: g = -d^T * Σ^{-1} * d)
+            // sigma = 0.5 * d^T * conic * d, where conic = Σ^{-1}
+            // ∂sigma/∂x = conic.x * d.x + conic.y * d.y
+            // ∂sigma/∂y = conic.y * d.x + conic.z * d.y
+            const float d_sigma_dx = conic.x * d.x + conic.y * d.y;
+            const float d_sigma_dy = conic.y * d.x + conic.z * d.y;
+
+            // ∂²sigma/∂x∂y = conic.y (the off-diagonal element of the conic matrix)
+            const float d2_sigma_dxdy = conic.y;
+
+            // α = exp(-sigma) (Eq. 36), ∂α/∂x = -α * ∂sigma/∂x
+            const float d_alpha_dx = -alpha * d_sigma_dx;
+            const float d_alpha_dy = -alpha * d_sigma_dy;
+
+            // ∂²α/∂x∂y = -α * (∂²sigma/∂x∂y - ∂sigma/∂x * ∂sigma/∂y)
+            const float d2_alpha_dxdy = -alpha * (d2_sigma_dxdy - d_sigma_dx * d_sigma_dy);
+
+            int32_t g = id_batch[t];
+            const float3 c = colors[g];
+            pix_out += c * alpha;
+
+            // Accumulate gradients for weighted summation (simplified from Eqs. 46-49)
+            // For weighted sum: I(x,y) = Σ c_i * α_i(x,y)
+            // ∂I/∂x = Σ c_i * ∂α_i/∂x (no alpha-compositing terms)
+            pix_dx += c * d_alpha_dx;
+
+            // ∂I/∂y = Σ c_i * ∂α_i/∂y
+            pix_dy += c * d_alpha_dy;
+
+            // ∂²I/∂x∂y = Σ c_i * ∂²α_i/∂x∂y
+            pix_dxy += c * d2_alpha_dxdy;
+
+            // Accumulate weighted sum of alphas
+            pix_wsum += alpha;
+
+            cur_idx = batch_start + t;
+        }
+    }
+
+    if (inside) {
+        final_index[pix_id] =
+            cur_idx; // index of in bin of last gaussian in this pixel
+        out_img[pix_id] = pix_out;
+        out_wsum[pix_id] = pix_wsum;
+        out_dx[pix_id] = pix_dx;
+        out_dy[pix_id] = pix_dy;
+        out_dxy[pix_id] = pix_dxy;
+    }
+}

--- a/gsplat2d/gsplat2d/cuda/csrc/gradient_aware_upscaler.cu
+++ b/gsplat2d/gsplat2d/cuda/csrc/gradient_aware_upscaler.cu
@@ -1,0 +1,371 @@
+#include "upscale.cuh"
+#include "helpers.cuh"
+#include <cooperative_groups.h>
+
+namespace cg = cooperative_groups;
+
+/*
+ * ============================================================================
+ * Gradient-Aware Bicubic Spline Upscaling for 3D Gaussian Splatting
+ * ============================================================================
+ * 
+ * Reference:
+ *   Niedermayr, S., Neuhauser, C., & Westermann, R. (2025).
+ *   "Lightweight Gradient-Aware Upscaling of 3D Gaussian Splatting Images"
+ *   arXiv:2503.14171v2 [cs.CV]
+ *   https://arxiv.org/abs/2503.14171
+ * 
+ * ============================================================================
+ * OVERVIEW
+ * ============================================================================
+ * 
+ * This implementation performs bicubic spline interpolation using analytical
+ * image gradients from 3DGS rendering, rather than finite-difference 
+ * approximations. The key insight is that 3DGS provides exact gradients 
+ * ∂I/∂x, ∂I/∂y, ∂²I/∂x∂y at each pixel, enabling more accurate spline fitting.
+ * 
+ * ============================================================================
+ * MATHEMATICAL FORMULATION
+ * ============================================================================
+ * 
+ * BICUBIC SPLINE PARAMETERIZATION (Section G, Eq. 21):
+ * 
+ *   p(x,y) = Σᵢ₌₀³ Σⱼ₌₀³ aᵢⱼ xⁱ yʲ
+ * 
+ * The spline coefficients A ∈ ℝ⁴ˣ⁴ are computed by solving (Eq. 25-26):
+ * 
+ *   F = C · A · Cᵀ
+ *   A = C⁻¹ · F · (Cᵀ)⁻¹
+ * 
+ * where F is the constraint matrix containing function values and derivatives
+ * at the four corner points of the interpolation cell.
+ * 
+ * F MATRIX LAYOUT (Eq. 6, 27):
+ * 
+ *   F = [ f(0,0)    f(0,1)    fᵧ(0,0)   fᵧ(0,1)  ]
+ *       [ f(1,0)    f(1,1)    fᵧ(1,0)   fᵧ(1,1)  ]
+ *       [ fₓ(0,0)   fₓ(0,1)   fₓᵧ(0,0)  fₓᵧ(0,1) ]
+ *       [ fₓ(1,0)   fₓ(1,1)   fₓᵧ(1,0)  fₓᵧ(1,1) ]
+ * 
+ * where:
+ *   f(i,j)    = pixel value at corner (i,j)
+ *   fₓ(i,j)   = ∂f/∂x at corner (i,j)  -- analytical gradient from 3DGS
+ *   fᵧ(i,j)   = ∂f/∂y at corner (i,j)  -- analytical gradient from 3DGS
+ *   fₓᵧ(i,j)  = ∂²f/∂x∂y at corner (i,j) -- mixed partial from 3DGS
+ * 
+ * C MATRIX (Eq. 28):
+ * 
+ * Derived from cubic polynomial constraints at x=0 and x=1:
+ *   f(x)  = a₀ + a₁x + a₂x² + a₃x³
+ *   f'(x) = a₁ + 2a₂x + 3a₃x²
+ * 
+ *   C = [ 1  0  0  0 ]    (f(0)  = a₀)
+ *       [ 1  1  1  1 ]    (f(1)  = a₀ + a₁ + a₂ + a₃)
+ *       [ 0  1  0  0 ]    (f'(0) = a₁)
+ *       [ 0  1  2  3 ]    (f'(1) = a₁ + 2a₂ + 3a₃)
+ * 
+ *   C⁻¹ = [  1   0   0   0 ]
+ *         [  0   0   1   0 ]
+ *         [ -3   3  -2  -1 ]
+ *         [  2  -2   1   1 ]
+ * 
+ * POLYNOMIAL EVALUATION (Eq. 7):
+ * 
+ *   p(x,y) = [1  x  x²  x³] · A · [1  y  y²  y³]ᵀ
+ * 
+ * ============================================================================
+ * BACKWARD PASS (Section 8.B)
+ * ============================================================================
+ * 
+ * For gradient backpropagation through the upscaling operation:
+ * 
+ *   p = pxᵀ · C⁻¹ · F · (C⁻¹)ᵀ · py
+ * 
+ * where px = [1, tx, tx², tx³]ᵀ and py = [1, ty, ty², ty³]ᵀ
+ * 
+ * The gradient w.r.t. each element of F is:
+ * 
+ *   ∂p/∂F[i,j] = (C⁻¹ᵀ · px)[i] · (C⁻¹ᵀ · py)[j]
+ * 
+ * This allows backpropagation of gradients to:
+ *   - grad_render: gradients w.r.t. pixel values f(i,j)
+ *   - grad_dx:     gradients w.r.t. x-derivatives fₓ(i,j)
+ *   - grad_dy:     gradients w.r.t. y-derivatives fᵧ(i,j)
+ *   - grad_dxy:    gradients w.r.t. mixed partials fₓᵧ(i,j)
+ * 
+ * ============================================================================
+ * 3DGS ANALYTICAL GRADIENTS (Section 5)
+ * ============================================================================
+ * 
+ * The image I(x,y) from 3DGS is computed via alpha blending (Eq. 3):
+ * 
+ *   I(x,y) = Σᵢ₌₁ᴺ Tᵢ(x,y) · αᵢ(x,y) · cᵢ
+ * 
+ * Analytical gradients are computed during rendering (Eq. 8-10):
+ * 
+ *   ∂I/∂x = Σᵢ cᵢ · (∂Tᵢ/∂x · αᵢ + Tᵢ · ∂αᵢ/∂x)
+ * 
+ *   ∂I/∂y = Σᵢ cᵢ · (∂Tᵢ/∂y · αᵢ + Tᵢ · ∂αᵢ/∂y)
+ * 
+ *   ∂²I/∂x∂y = Σᵢ cᵢ · (∂²Tᵢ/∂x∂y · αᵢ + ∂Tᵢ/∂x · ∂αᵢ/∂y 
+ *                       + ∂Tᵢ/∂y · ∂αᵢ/∂x + Tᵢ · ∂²αᵢ/∂x∂y)
+ * 
+ * These gradients are computed iteratively during the blending loop with
+ * minimal overhead, then passed to this upscaling kernel.
+ * 
+ * ============================================================================
+ * IMPLEMENTATION NOTES
+ * ============================================================================
+ * 
+ * - Forward kernel: computes A = C⁻¹ · F · (C⁻¹)ᵀ, then evaluates p(tx,ty)
+ * - Backward kernel: computes ∂p/∂F and accumulates via atomicAdd
+ * - Memory layout: CHW format (channels × height × width)
+ * - ROI support: allows upscaling a subregion of the source image
+ * 
+ * ============================================================================
+ */
+
+// C^(-1) matrix for cubic spline (stored in row-major)
+// C = [1 0 0 0;
+//      1 1 1 1;
+//      0 1 0 0;
+//      0 1 2 3]
+// C^(-1) = [1 0 0 0;
+//           0 0 1 0;
+//           -3 3 -2 -1;
+//           2 -2 1 1]
+__constant__ float C_inv[16] = {
+    1.0f,  0.0f,  0.0f,  0.0f,
+    0.0f,  0.0f,  1.0f,  0.0f,
+   -3.0f,  3.0f, -2.0f, -1.0f,
+    2.0f, -2.0f,  1.0f,  1.0f
+};
+
+// Compute C_inv^T * p vector (used for both px and py)
+__device__ __forceinline__ void compute_C_inv_T_p(float t, float* out) {
+    // C_inv^T[i,k] = C_inv[k,i]
+    // out[i] = sum_k C_inv[k*4+i] * p[k] where p = [1, t, t², t³]
+    const float t2 = t * t;
+    const float t3 = t2 * t;
+    out[0] = C_inv[0] * 1.0f + C_inv[4] * t + C_inv[8] * t2 + C_inv[12] * t3;
+    out[1] = C_inv[1] * 1.0f + C_inv[5] * t + C_inv[9] * t2 + C_inv[13] * t3;
+    out[2] = C_inv[2] * 1.0f + C_inv[6] * t + C_inv[10] * t2 + C_inv[14] * t3;
+    out[3] = C_inv[3] * 1.0f + C_inv[7] * t + C_inv[11] * t2 + C_inv[15] * t3;
+}
+
+// Interpolate single channel using precomputed coefficients
+// F layout (column-major, matching original):
+//   col0: [f00, f01, fx00, fx01]
+//   col1: [f10, f11, fx10, fx11]  
+//   col2: [fy00, fy01, fxy00, fxy01]
+//   col3: [fy10, fy11, fxy10, fxy11]
+// Result = (C_inv^T * px)^T * F * (C_inv^T * py)
+template<typename T>
+__device__ __forceinline__ T spline_interp(
+    T f00, T f01, T f10, T f11,
+    T fx00, T fx01, T fx10, T fx11,
+    T fy00, T fy01, T fy10, T fy11,
+    T fxy00, T fxy01, T fxy10, T fxy11,
+    const float* cx, const float* cy
+) {
+    // F * cy (4 elements)
+    T Fcy0 = f00 * cy[0] + f10 * cy[1] + fy00 * cy[2] + fy10 * cy[3];
+    T Fcy1 = f01 * cy[0] + f11 * cy[1] + fy01 * cy[2] + fy11 * cy[3];
+    T Fcy2 = fx00 * cy[0] + fx10 * cy[1] + fxy00 * cy[2] + fxy10 * cy[3];
+    T Fcy3 = fx01 * cy[0] + fx11 * cy[1] + fxy01 * cy[2] + fxy11 * cy[3];
+    
+    // cx^T * (F * cy)
+    return cx[0] * Fcy0 + cx[1] * Fcy1 + cx[2] * Fcy2 + cx[3] * Fcy3;
+}
+
+__global__ void gradient_aware_upscale_kernel(
+    const int dst_h,
+    const int dst_w,
+    const int src_h,
+    const int src_w,
+    const float roi_x1,
+    const float roi_y1,
+    const float roi_x2,
+    const float roi_y2,
+    const float3* __restrict__ render,  // [H, W] of float3 (HWC)
+    const float3* __restrict__ dx,
+    const float3* __restrict__ dy,
+    const float3* __restrict__ dxy,
+    float3* __restrict__ output
+) {
+    const int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (dst_x >= dst_w || dst_y >= dst_h) return;
+
+    const int roi_w = roi_x2 - roi_x1;
+    const int roi_h = roi_y2 - roi_y1;
+
+    // Map dst coords to src ROI coords
+    const float src_x = roi_x1 + (dst_x + 0.5f) * roi_w / dst_w - 0.5f;
+    const float src_y = roi_y1 + (dst_y + 0.5f) * roi_h / dst_h - 0.5f;
+
+    // Get integer and fractional parts
+    int x0 = floorf(src_x);
+    int y0 = floorf(src_y);
+    float tx = src_x - x0;
+    float ty = src_y - y0;
+
+    // Clamp indices
+    int x1 = min(x0 + 1, src_w - 1);
+    int y1 = min(y0 + 1, src_h - 1);
+    x0 = max(0, min(x0, src_w - 1));
+    y0 = max(0, min(y0, src_h - 1));
+
+    // Precompute C_inv^T * px and C_inv^T * py (same for all channels)
+    float cx[4], cy[4];
+    compute_C_inv_T_p(tx, cx);
+    compute_C_inv_T_p(ty, cy);
+
+    // Load float3 values at 4 corners (coalesced HWC access)
+    const int idx00 = y0 * src_w + x0;
+    const int idx01 = y0 * src_w + x1;
+    const int idx10 = y1 * src_w + x0;
+    const int idx11 = y1 * src_w + x1;
+
+    const float3 f00 = render[idx00], f01 = render[idx01], f10 = render[idx10], f11 = render[idx11];
+    const float3 fx00 = dx[idx00], fx01 = dx[idx01], fx10 = dx[idx10], fx11 = dx[idx11];
+    const float3 fy00 = dy[idx00], fy01 = dy[idx01], fy10 = dy[idx10], fy11 = dy[idx11];
+    const float3 fxy00 = dxy[idx00], fxy01 = dxy[idx01], fxy10 = dxy[idx10], fxy11 = dxy[idx11];
+
+    // Interpolate each channel
+    float3 result = spline_interp(
+        f00, f01, f10, f11,
+        fx00, fx01, fx10, fx11,
+        fy00, fy01, fy10, fy11,
+        fxy00, fxy01, fxy10, fxy11,
+        cx, cy
+    );
+
+    output[dst_y * dst_w + dst_x] = result;
+}
+
+__global__ void gradient_aware_upscale_backward_kernel(
+    const int dst_h,
+    const int dst_w,
+    const int src_h,
+    const int src_w,
+    const float roi_x1,
+    const float roi_y1,
+    const float roi_x2,
+    const float roi_y2,
+    const float3* __restrict__ grad_output,  // [dst_H, dst_W] of float3
+    float3* __restrict__ grad_render,        // [src_H, src_W] of float3
+    float3* __restrict__ grad_dx,
+    float3* __restrict__ grad_dy,
+    float3* __restrict__ grad_dxy
+) {
+    const int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (dst_x >= dst_w || dst_y >= dst_h) return;
+
+    const int roi_w = roi_x2 - roi_x1;
+    const int roi_h = roi_y2 - roi_y1;
+
+    const float src_x = roi_x1 + (dst_x + 0.5f) * roi_w / dst_w - 0.5f;
+    const float src_y = roi_y1 + (dst_y + 0.5f) * roi_h / dst_h - 0.5f;
+
+    int x0 = floorf(src_x);
+    int y0 = floorf(src_y);
+    float tx = src_x - x0;
+    float ty = src_y - y0;
+
+    int x1 = min(x0 + 1, src_w - 1);
+    int y1 = min(y0 + 1, src_h - 1);
+    x0 = max(0, min(x0, src_w - 1));
+    y0 = max(0, min(y0, src_h - 1));
+
+    // Precompute C_inv^T * px and C_inv * py
+    float cx[4], cy[4];
+    compute_C_inv_T_p(tx, cx);
+    compute_C_inv_T_p(ty, cy);
+
+    // p = px^T * C_inv * F * C_inv^T * py
+    // ∂p/∂F[i,j] = cx[i] * cy[j]
+    //
+    // F layout (row-major):
+    // row 0: [f00,  f10,  fy00,  fy10 ]
+    // row 1: [f01,  f11,  fy01,  fy11 ]
+    // row 2: [fx00, fx10, fxy00, fxy10]
+    // row 3: [fx01, fx11, fxy01, fxy11]
+
+    const float3 g = grad_output[dst_y * dst_w + dst_x];
+
+    // Precompute coefficient products (same for all channels)
+    const float c00 = cx[0] * cy[0], c01 = cx[0] * cy[1], c02 = cx[0] * cy[2], c03 = cx[0] * cy[3];
+    const float c10 = cx[1] * cy[0], c11 = cx[1] * cy[1], c12 = cx[1] * cy[2], c13 = cx[1] * cy[3];
+    const float c20 = cx[2] * cy[0], c21 = cx[2] * cy[1], c22 = cx[2] * cy[2], c23 = cx[2] * cy[3];
+    const float c30 = cx[3] * cy[0], c31 = cx[3] * cy[1], c32 = cx[3] * cy[2], c33 = cx[3] * cy[3];
+
+    // Corner indices
+    const int idx00 = y0 * src_w + x0;
+    const int idx01 = y0 * src_w + x1;
+    const int idx10 = y1 * src_w + x0;
+    const int idx11 = y1 * src_w + x1;
+
+    // grad_render: F[0,0]=f00, F[0,1]=f10, F[1,0]=f01, F[1,1]=f11
+    float* gr = (float*)grad_render;
+    atomicAdd(&gr[idx00 * 3 + 0], g.x * c00);
+    atomicAdd(&gr[idx00 * 3 + 1], g.y * c00);
+    atomicAdd(&gr[idx00 * 3 + 2], g.z * c00);
+    atomicAdd(&gr[idx01 * 3 + 0], g.x * c10);
+    atomicAdd(&gr[idx01 * 3 + 1], g.y * c10);
+    atomicAdd(&gr[idx01 * 3 + 2], g.z * c10);
+    atomicAdd(&gr[idx10 * 3 + 0], g.x * c01);
+    atomicAdd(&gr[idx10 * 3 + 1], g.y * c01);
+    atomicAdd(&gr[idx10 * 3 + 2], g.z * c01);
+    atomicAdd(&gr[idx11 * 3 + 0], g.x * c11);
+    atomicAdd(&gr[idx11 * 3 + 1], g.y * c11);
+    atomicAdd(&gr[idx11 * 3 + 2], g.z * c11);
+
+    // grad_dx: F[2,0]=fx00, F[2,1]=fx10, F[3,0]=fx01, F[3,1]=fx11
+    float* gx = (float*)grad_dx;
+    atomicAdd(&gx[idx00 * 3 + 0], g.x * c20);
+    atomicAdd(&gx[idx00 * 3 + 1], g.y * c20);
+    atomicAdd(&gx[idx00 * 3 + 2], g.z * c20);
+    atomicAdd(&gx[idx01 * 3 + 0], g.x * c30);
+    atomicAdd(&gx[idx01 * 3 + 1], g.y * c30);
+    atomicAdd(&gx[idx01 * 3 + 2], g.z * c30);
+    atomicAdd(&gx[idx10 * 3 + 0], g.x * c21);
+    atomicAdd(&gx[idx10 * 3 + 1], g.y * c21);
+    atomicAdd(&gx[idx10 * 3 + 2], g.z * c21);
+    atomicAdd(&gx[idx11 * 3 + 0], g.x * c31);
+    atomicAdd(&gx[idx11 * 3 + 1], g.y * c31);
+    atomicAdd(&gx[idx11 * 3 + 2], g.z * c31);
+
+    // grad_dy: F[0,2]=fy00, F[0,3]=fy10, F[1,2]=fy01, F[1,3]=fy11
+    float* gy = (float*)grad_dy;
+    atomicAdd(&gy[idx00 * 3 + 0], g.x * c02);
+    atomicAdd(&gy[idx00 * 3 + 1], g.y * c02);
+    atomicAdd(&gy[idx00 * 3 + 2], g.z * c02);
+    atomicAdd(&gy[idx01 * 3 + 0], g.x * c12);
+    atomicAdd(&gy[idx01 * 3 + 1], g.y * c12);
+    atomicAdd(&gy[idx01 * 3 + 2], g.z * c12);
+    atomicAdd(&gy[idx10 * 3 + 0], g.x * c03);
+    atomicAdd(&gy[idx10 * 3 + 1], g.y * c03);
+    atomicAdd(&gy[idx10 * 3 + 2], g.z * c03);
+    atomicAdd(&gy[idx11 * 3 + 0], g.x * c13);
+    atomicAdd(&gy[idx11 * 3 + 1], g.y * c13);
+    atomicAdd(&gy[idx11 * 3 + 2], g.z * c13);
+
+    // grad_dxy: F[2,2]=fxy00, F[2,3]=fxy10, F[3,2]=fxy01, F[3,3]=fxy11
+    float* gxy = (float*)grad_dxy;
+    atomicAdd(&gxy[idx00 * 3 + 0], g.x * c22);
+    atomicAdd(&gxy[idx00 * 3 + 1], g.y * c22);
+    atomicAdd(&gxy[idx00 * 3 + 2], g.z * c22);
+    atomicAdd(&gxy[idx01 * 3 + 0], g.x * c32);
+    atomicAdd(&gxy[idx01 * 3 + 1], g.y * c32);
+    atomicAdd(&gxy[idx01 * 3 + 2], g.z * c32);
+    atomicAdd(&gxy[idx10 * 3 + 0], g.x * c23);
+    atomicAdd(&gxy[idx10 * 3 + 1], g.y * c23);
+    atomicAdd(&gxy[idx10 * 3 + 2], g.z * c23);
+    atomicAdd(&gxy[idx11 * 3 + 0], g.x * c33);
+    atomicAdd(&gxy[idx11 * 3 + 1], g.y * c33);
+    atomicAdd(&gxy[idx11 * 3 + 2], g.z * c33);
+}

--- a/gsplat2d/gsplat2d/cuda/csrc/helpers.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/helpers.cuh
@@ -75,3 +75,21 @@ inline __device__ void cov2d_to_conic_vjp(
     v_cov2d.y = v_Sigma[1][0] + v_Sigma[0][1];
     v_cov2d.z = v_Sigma[1][1];
 }
+
+
+// Explicit float3 operations (duplicated from helper_math.h for visibility)
+inline __host__ __device__ float3 operator+(float3 a, float3 b) {
+    return make_float3(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+inline __host__ __device__ void operator+=(float3 &a, float3 b) {
+    a.x += b.x; a.y += b.y; a.z += b.z;
+}
+inline __host__ __device__ float3 operator*(float3 a, float b) {
+    return make_float3(a.x * b, a.y * b, a.z * b);
+}
+inline __host__ __device__ float3 operator*(float b, float3 a) {
+    return make_float3(b * a.x, b * a.y, b * a.z);
+}
+inline __host__ __device__ void operator*=(float3 &a, float b) {
+    a.x *= b; a.y *= b; a.z *= b;
+}

--- a/gsplat2d/gsplat2d/cuda/csrc/helpers.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/helpers.cuh
@@ -2,6 +2,8 @@
 #include <cuda_runtime.h>
 #include "third_party/glm/glm/glm.hpp"
 #include "third_party/glm/glm/gtc/type_ptr.hpp"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
 #include <iostream>
 
 inline __device__ void get_bbox(
@@ -74,6 +76,23 @@ inline __device__ void cov2d_to_conic_vjp(
     v_cov2d.x = v_Sigma[0][0];
     v_cov2d.y = v_Sigma[1][0] + v_Sigma[0][1];
     v_cov2d.z = v_Sigma[1][1];
+}
+
+namespace cg = cooperative_groups;
+
+inline __device__ void warpSum3(float3& val, cg::thread_block_tile<32>& tile){
+    val.x = cg::reduce(tile, val.x, cg::plus<float>());
+    val.y = cg::reduce(tile, val.y, cg::plus<float>());
+    val.z = cg::reduce(tile, val.z, cg::plus<float>());
+}
+
+inline __device__ void warpSum2(float2& val, cg::thread_block_tile<32>& tile){
+    val.x = cg::reduce(tile, val.x, cg::plus<float>());
+    val.y = cg::reduce(tile, val.y, cg::plus<float>());
+}
+
+inline __device__ void warpSum(float& val, cg::thread_block_tile<32>& tile){
+    val = cg::reduce(tile, val, cg::plus<float>());
 }
 
 

--- a/gsplat2d/gsplat2d/cuda/csrc/upscale.cuh
+++ b/gsplat2d/gsplat2d/cuda/csrc/upscale.cuh
@@ -1,0 +1,36 @@
+#pragma once
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+__global__ void gradient_aware_upscale_kernel(
+    const int dst_h,
+    const int dst_w,
+    const int src_h,
+    const int src_w,
+    const float roi_x1,
+    const float roi_y1,
+    const float roi_x2,
+    const float roi_y2,
+    const float3* __restrict__ render,   // [H, W] of float3 (HWC)
+    const float3* __restrict__ dx,
+    const float3* __restrict__ dy,
+    const float3* __restrict__ dxy,
+    float3* __restrict__ output          // [dst_h, dst_w] of float3 (HWC)
+);
+
+__global__ void gradient_aware_upscale_backward_kernel(
+    const int dst_h,
+    const int dst_w,
+    const int src_h,
+    const int src_w,
+    const float roi_x1,
+    const float roi_y1,
+    const float roi_x2,
+    const float roi_y2,
+    const float3* __restrict__ grad_output,  // [dst_H, dst_W] of float3
+    float3* __restrict__ grad_render,        // [src_H, src_W] of float3
+    float3* __restrict__ grad_dx,
+    float3* __restrict__ grad_dy,
+    float3* __restrict__ grad_dxy
+);

--- a/gsplat2d/gsplat2d/project_gaussians_cholesky.py
+++ b/gsplat2d/gsplat2d/project_gaussians_cholesky.py
@@ -1,0 +1,107 @@
+from typing import Tuple
+
+from jaxtyping import Float
+from torch import Tensor
+from torch.autograd import Function
+
+from gsplat2d import cuda as _C
+
+
+def project_gaussians_cholesky(
+    cholesky: Float[Tensor, "*batch 3"],
+    means2d: Float[Tensor, "*batch 2"],
+    img_height: int,
+    img_width: int,
+    block_width: int,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Project gaussians directly from cholesky decomposition.
+
+    Args:
+        cholesky: [l11, l21, l22] elements of lower triangular cholesky factor
+        means2d: 2D positions
+        img_height, img_width: image dimensions
+        block_width: tile block width (2-16)
+
+    Returns:
+        xys, radii, conics, num_tiles_hit
+    """
+    assert block_width > 1 and block_width <= 16, "block_width must be between 2 and 16"
+    return _ProjectGaussiansCholesky.apply(
+        cholesky.contiguous(),
+        means2d.contiguous(),
+        img_height,
+        img_width,
+        block_width,
+    )
+
+
+class _ProjectGaussiansCholesky(Function):
+
+    @staticmethod
+    def forward(
+        ctx,
+        cholesky: Float[Tensor, "*batch 3"],
+        means2d: Float[Tensor, "*batch 2"],
+        img_height: int,
+        img_width: int,
+        block_width: int,
+    ):
+        num_points = cholesky.shape[-2]
+        if num_points < 1 or cholesky.shape[-1] != 3:
+            raise ValueError(f"Invalid shape for cholesky: {cholesky.shape}")
+
+        (
+            xys,
+            radii,
+            conics,
+            num_tiles_hit,
+        ) = _C.project_gaussians_forward_cholesky(
+            num_points,
+            cholesky,
+            means2d,
+            img_height,
+            img_width,
+            block_width,
+        )
+
+        ctx.img_height = img_height
+        ctx.img_width = img_width
+        ctx.num_points = num_points
+
+        ctx.save_for_backward(
+            radii,
+            cholesky,
+            conics,
+        )
+
+        return (xys, radii, conics, num_tiles_hit)
+
+    @staticmethod
+    def backward(
+        ctx,
+        v_xys,
+        v_radii,
+        v_conics,
+        v_num_tiles_hit
+    ):
+        (
+            radii,
+            cholesky,
+            conics,
+        ) = ctx.saved_tensors
+
+        v_cholesky, v_mean2d = _C.project_gaussians_backward_cholesky(
+            ctx.num_points,
+            radii,
+            cholesky,
+            conics,
+            v_xys,
+            v_conics,
+        )
+        return (
+            v_cholesky,
+            v_mean2d,
+            None,
+            None,
+            None,
+        )

--- a/gsplat2d/gsplat2d/rasterize.py
+++ b/gsplat2d/gsplat2d/rasterize.py
@@ -12,7 +12,7 @@ from .utils import bin_and_sort_gaussians, compute_cumulative_intersects
 
 def rasterize_gaussians(
     xys: Float[Tensor, "*batch 2"],
-    radii: Float[Tensor, "*batch 1"],
+    extents: Float[Tensor, "*batch 2"],
     conics: Float[Tensor, "*batch 3"],
     num_tiles_hit: Int[Tensor, "*batch 1"],
     colors: Float[Tensor, "*batch channels"],
@@ -34,7 +34,7 @@ def rasterize_gaussians(
 
     return _RasterizeGaussians.apply(
         xys.contiguous(),
-        radii.contiguous(),
+        extents.contiguous(),
         conics.contiguous(),
         num_tiles_hit.contiguous(),
         colors.contiguous(),
@@ -52,7 +52,7 @@ class _RasterizeGaussians(Function):
     def forward(
         ctx,
         xys: Float[Tensor, "*batch 2"],
-        radii: Float[Tensor, "*batch 1"],
+        extents: Float[Tensor, "*batch 2"],
         conics: Float[Tensor, "*batch 3"],
         num_tiles_hit: Int[Tensor, "*batch 1"],
         colors: Float[Tensor, "*batch channels"],
@@ -97,7 +97,7 @@ class _RasterizeGaussians(Function):
                 num_intersects,
                 xys,
                 depths,
-                radii,
+                extents,
                 cum_tiles_hit,
                 tile_bounds,
                 block_width,
@@ -177,7 +177,7 @@ class _RasterizeGaussians(Function):
 
         return (
             v_xy,  # xys
-            None,  # radii
+            None,  # extents
             v_conic,  # conics
             None,  # num_tiles_hit
             v_colors,  # colors

--- a/gsplat2d/gsplat2d/upscale.py
+++ b/gsplat2d/gsplat2d/upscale.py
@@ -1,0 +1,82 @@
+"""Bicubic spline upscaling using analytical gradients from rasterization"""
+
+from typing import Optional, Tuple
+from torch import Tensor
+from torch.autograd import Function
+
+import gsplat2d.cuda as _C
+
+
+class _GradientAwareSplineUpscale(Function):
+    @staticmethod
+    def forward(
+        ctx,
+        render: Tensor,  # [H, W, 3]
+        dx: Tensor,
+        dy: Tensor,
+        dxy: Tensor,
+        dst_h: int,
+        dst_w: int,
+        roi: tuple[float, float, float, float],
+    ) -> Tensor:
+        ctx.save_for_backward(render, dx, dy, dxy)
+        ctx.dst_h = dst_h
+        ctx.dst_w = dst_w
+        ctx.roi = roi
+        
+        output = _C.gradient_aware_upscale_forward(
+            render, dx, dy, dxy, dst_h, dst_w, roi
+        )
+        return output
+    
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        render, dx, dy, dxy = ctx.saved_tensors
+        
+        grad_render, grad_dx, grad_dy, grad_dxy = _C.gradient_aware_upscale_backward(
+            grad_output.contiguous(),
+            render,
+            dx,
+            dy,
+            dxy,
+            ctx.dst_h,
+            ctx.dst_w,
+            ctx.roi,
+        )
+        
+        return grad_render, grad_dx, grad_dy, grad_dxy, None, None, None
+
+
+def gradient_aware_upscale(
+    render: Tensor,  # [H, W, 3]
+    dx: Tensor,      # [H, W, 3]
+    dy: Tensor,      # [H, W, 3]
+    dxy: Tensor,     # [H, W, 3]
+    dst_h: int,
+    dst_w: int,
+    roi: Optional[Tuple[float, float, float, float]] = None,  # (x1, y1, x2, y2)
+) -> Tensor:
+    """
+    Bicubic spline interpolation using analytical gradients.
+    
+    Args:
+        render: Rendered image [H, W, 3]
+        dx: Gradient w.r.t. x [H, W, 3]
+        dy: Gradient w.r.t. y [H, W, 3]
+        dxy: Mixed partial derivative [H, W, 3]
+        dst_h: Output height
+        dst_w: Output width
+        roi: Region of interest (x1, y1, x2, y2), defaults to full image
+    
+    Returns:
+        Upscaled image [dst_h, dst_w, 3]
+    """
+    h, w, c = render.shape
+    
+    if roi is None:
+        roi = (0.0, 0.0, float(w), float(h))
+    
+    return _GradientAwareSplineUpscale.apply(
+        render.contiguous(), dx.contiguous(), dy.contiguous(), dxy.contiguous(),
+        dst_h, dst_w, roi
+    )

--- a/minimal_trainer_upscale.py
+++ b/minimal_trainer_upscale.py
@@ -1,0 +1,275 @@
+"""Minimal trainer for 2D Gaussian splatting with optional bicubic upscale"""
+
+# =============================================================================
+# RESOLUTION LOGIC:
+# 
+# 1. Load image, optionally downscale to MAX_TRAIN_RESOLUTION -> this is gt_full
+# 2. gt_full is ALWAYS the target for loss comparison (H_full x W_full)
+#
+# WITHOUT upscale (USE_UPSCALE=False):
+#   - Model trains at gt_full resolution (H_train = H_full)
+#   - Loss: render vs gt_full directly
+#
+# WITH upscale (USE_UPSCALE=True):
+#   - Model trains at MODEL_RESOLUTION (max dimension)
+#   - Render upscaled via bicubic_spline_upscale before comparison
+#   - Loss: upscaled_render vs gt_full
+# =============================================================================
+
+import math
+import time
+from tqdm import tqdm
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
+import torchvision.transforms as transforms
+
+from optimizer import Adan
+from gsplat2d.rasterize import rasterize_gaussians
+from gsplat2d.project_gaussians_cholesky import project_gaussians_cholesky
+from gsplat2d.upscale import gradient_aware_upscale
+from upscaler_torch import torch_gradient_aware_upscale
+
+
+# ============ CONFIG ============
+IMAGE_PATH = r"x:\_ai\_gsplat\datasets\DIV2K_valid_HR\0900.png"
+NUM_POINTS = 500_000
+ITERATIONS = 10000
+LR = 0.015
+USE_UPSCALE = True
+USE_TORCH_UPSCALE = False  # True = torch impl, False = gsplat2d CUDA impl
+MODEL_RESOLUTION = 1200  # train at this max dimension, upscale to full
+MAX_TRAIN_RESOLUTION = None # if set, downscale gt to fit this max dimension before training
+DEVICE = torch.device("cuda:0")
+# ================================
+
+
+def init_splats_simple(
+    num_points: int, H: int, W: int, device,
+    mode: str = 'grid',
+    image: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if mode == 'grid':
+        aspect = W / H
+        ny = max(1, int(math.sqrt(num_points / aspect)))
+        nx = max(1, int(num_points / ny))
+        ys = torch.linspace(0.5, H - 0.5, ny, device=device)
+        xs = torch.linspace(0.5, W - 0.5, nx, device=device)
+        grid_y, grid_x = torch.meshgrid(ys, xs, indexing='ij')
+        positions = torch.stack([grid_x.flatten(), grid_y.flatten()], dim=1)
+        num_points = positions.shape[0]
+    else:
+        positions = torch.rand(num_points, 2, device=device) * torch.tensor([W, H], device=device)
+
+    scales = torch.full((num_points,), math.sqrt(H * W / num_points) * 0.5, device=device)
+
+    if image is not None:
+        img = image.squeeze(0) if image.dim() == 4 else image
+        x_coords = positions[:, 0].long().clamp(0, W - 1)
+        y_coords = positions[:, 1].long().clamp(0, H - 1)
+        rgbs = img[:, y_coords, x_coords].T
+    else:
+        rgbs = torch.full((num_points, 3), 0.5, device=device)
+
+    return positions.contiguous(), rgbs.contiguous(), scales.contiguous()
+
+# ================================
+
+
+class Gaussian2DMinimal(nn.Module):
+    def __init__(self, num_points: int, H: int, W: int, device,
+                 positions: torch.Tensor | None = None,
+                 rgbs: torch.Tensor | None = None,
+                 scales: torch.Tensor | None = None):
+        super().__init__()
+        self.H = H
+        self.W = W
+        self.device = device
+        self.B_SIZE = 16
+
+        if positions is None:
+            positions = torch.rand(num_points, 2, device=device) * torch.tensor([W, H], device=device)
+        if rgbs is None:
+            rgbs = torch.full((num_points, 3), 0.5, dtype=torch.float32, device=device)
+        if scales is None:
+            scales = torch.full((num_points,), math.sqrt(H * W / num_points) * 0.5, dtype=torch.float32, device=device)
+
+        self.means = nn.Parameter(positions)
+        self._rgb_logits = nn.Parameter(torch.logit(rgbs.clamp(0.001, 0.999)))
+        self._opacity_logits = nn.Parameter(torch.zeros(num_points, device=device))
+
+        # Circular splats: L11=scale, L21=0, L22=scale
+        # _cholesky stores pre-softplus values, need inverse softplus
+        diag = torch.log(torch.expm1(scales))
+        x_L21 = torch.zeros(num_points, device=device)
+        self._cholesky = nn.Parameter(torch.stack([diag, x_L21, diag], dim=1))
+
+    @property
+    def cholesky(self):
+        L11 = F.softplus(self._cholesky[:, 0])
+        L21 = self._cholesky[:, 1]  # no softplus
+        L22 = F.softplus(self._cholesky[:, 2])
+        return torch.stack([L11, L21, L22], dim=1)
+
+    @property
+    def rgbs(self):
+        return torch.sigmoid(self._rgb_logits)
+
+    @property
+    def opacities(self):
+        return torch.sigmoid(self._opacity_logits)
+
+    def forward(self):
+        xys, extents, conics, num_tiles_hit = project_gaussians_cholesky(
+            self.cholesky, self.means, self.H, self.W, self.B_SIZE, self.opacities
+        )
+        out_img, out_wsum, dx, dy, dxy = rasterize_gaussians(
+            xys, extents, conics, num_tiles_hit,
+            self.rgbs, self.opacities,
+            self.H, self.W, self.B_SIZE,
+            compute_upscale_gradients=True
+        )
+        return {
+            "render": out_img.permute(2, 0, 1),
+            "render_hwc": out_img, "wsum": out_wsum, "dx": dx, "dy": dy, "dxy": dxy,
+        }
+
+    def scale_to(self, new_H: int, new_W: int):
+        """Scale parameters to new resolution"""
+        scale_x = new_W / self.W
+        scale_y = new_H / self.H
+
+        with torch.no_grad():
+            self.means.data[:, 0] *= scale_x
+            self.means.data[:, 1] *= scale_y
+
+            # L11, L22: softplus -> scale -> inverse softplus
+            L11 = F.softplus(self._cholesky.data[:, 0])
+            L22 = F.softplus(self._cholesky.data[:, 2])
+            L11_new = L11 * scale_x
+            L22_new = L22 * scale_y
+            self._cholesky.data[:, 0] = torch.log(torch.clamp(torch.exp(L11_new) - 1, min=1e-8))
+            self._cholesky.data[:, 2] = torch.log(torch.clamp(torch.exp(L22_new) - 1, min=1e-8))
+            # L21: no softplus, just scale
+            self._cholesky.data[:, 1] *= scale_y
+
+        self.H = new_H
+        self.W = new_W
+
+
+def upscale_fn(out, target_h, target_w, use_torch_upscale):
+    render_hwc = out["render_hwc"]
+    dx_hwc = out["dx"]
+    dy_hwc = out["dy"]
+    dxy_hwc = out["dxy"]
+    if use_torch_upscale:
+        return torch_gradient_aware_upscale(render_hwc, dx_hwc, dy_hwc, dxy_hwc, target_h, target_w)
+    else:
+        return gradient_aware_upscale(render_hwc, dx_hwc, dy_hwc, dxy_hwc, target_h, target_w)
+
+def train(image_path: str, num_points: int, iterations: int, lr: float,
+          use_upscale: bool, model_resolution: int, device,
+          max_train_resolution: int | None = None,
+          use_torch_upscale: bool = False):
+
+    img = Image.open(image_path)
+    gt_image = transforms.ToTensor()(img)[:3, ...].unsqueeze(0).to(device)  # [1, C, H, W]
+    del img
+
+    H_gt, W_gt = gt_image.shape[2], gt_image.shape[3]
+
+    # Optional downscale to max_train_resolution
+    if max_train_resolution is not None:
+        max_dim = max(H_gt, W_gt)
+        if max_dim > max_train_resolution:
+            scale = max_train_resolution / max_dim
+            H_gt, W_gt = round(H_gt * scale), round(W_gt * scale)
+            gt_image = F.interpolate(gt_image, size=(H_gt, W_gt), mode='area')
+
+    if use_upscale:
+        scale = model_resolution / max(H_gt, W_gt)
+        H_model = round(H_gt * scale)
+        W_model = round(W_gt * scale)
+    else:
+        H_model, W_model = H_gt, W_gt
+
+    gt_for_init = gt_image if gt_image.shape[2:] == (H_model, W_model) else F.interpolate(gt_image, size=(H_model, W_model), mode='area')
+
+    positions, rgbs, scales = init_splats_simple(num_points, H_model, W_model, device, mode="grid", image=gt_for_init)
+    actual_num_points = positions.shape[0]
+    model = Gaussian2DMinimal(actual_num_points, H_model, W_model, device, positions=positions, rgbs=rgbs, scales=scales).to(device)
+
+    pos_lr_scale = max(H_model, W_model) / 512.0
+    optimizer = Adan([
+        {'params': model._rgb_logits, 'lr': lr * 5},
+        {'params': model.means, 'lr': lr * 2 * pos_lr_scale},
+        {'params': model._cholesky, 'lr': lr * 1 * pos_lr_scale},
+        {'params': model._opacity_logits, 'lr': lr}
+    ], betas=(0.98, 0.92, 0.99), fused=True)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+        optimizer, T_0=iterations, T_mult=1, eta_min=lr * 0.01
+    )
+
+    gt_hwc = gt_image.squeeze(0).permute(1, 2, 0)  # [H_train, W_train, C]
+    gt_scale = max(H_gt, W_gt) / max(H_model, W_model) if use_upscale else 1.0
+
+    start = time.monotonic()
+    psnr = 0.0
+    pbar = tqdm(range(1, iterations + 1), desc="Training")
+    for it in pbar:
+        out = model()
+        compare_img = out["render_hwc"] if not use_upscale else upscale_fn(out, H_gt, W_gt, use_torch_upscale)
+        loss = F.mse_loss(compare_img, gt_hwc)
+
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+        scheduler.step()
+
+        if it % 100 == 0:
+            with torch.no_grad():
+                mse = F.mse_loss(compare_img, gt_hwc)
+                psnr = 10 * math.log10(1.0 / mse.item())
+                chol = model.cholesky
+                splat_sizes = torch.sqrt((chol[:, 0] * chol[:, 2]))  # sqrt(L11 * L22) ~ geom mean of axes
+                p1, p50, p99 = torch.quantile(splat_sizes, torch.tensor([0.01, 0.5, 0.99], device=device))
+                pbar.set_postfix(loss=f"{loss.item():.5f}", psnr=f"{psnr:.2f}", 
+                                 sz=f"min:{p1.item() * gt_scale:.2f}px, mean:{p50.item() * gt_scale:.2f}px, max:{p99.item() * gt_scale:.2f}px")
+
+    elapsed = time.monotonic() - start
+    print(f"Training done in {elapsed:.2f}s")
+
+    # Final eval
+    model.eval()
+    with torch.no_grad():
+        out = model()
+        if use_upscale:
+            render_native = torch.clamp(out["render_hwc"], 0, 1)
+            render_upscaled = torch.clamp(upscale_fn(out, H_gt, W_gt, use_torch_upscale), 0, 1)
+            mse = F.mse_loss(render_upscaled, gt_hwc)
+        else:
+            render_native = torch.clamp(out["render_hwc"], 0, 1)
+            mse = F.mse_loss(render_native, gt_hwc)
+        psnr = 10 * math.log10(1.0 / mse.item())
+        print(f"Final PSNR: {psnr:.4f}")
+
+        n_suffix = f"{actual_num_points / 1_000_000:.0f}M" if actual_num_points >= 2_500_000 else f"{actual_num_points / 1000:.0f}k"
+        transforms.ToPILImage()(render_native.permute(2, 0, 1)).save(f"result_native_{n_suffix}.png")
+        if use_upscale:
+            transforms.ToPILImage()(render_upscaled.permute(2, 0, 1)).save(f"result_upscaled_{n_suffix}.png")
+
+
+if __name__ == "__main__":
+    train(
+        image_path=IMAGE_PATH,
+        num_points=NUM_POINTS,
+        iterations=ITERATIONS,
+        lr=LR,
+        use_upscale=USE_UPSCALE,
+        model_resolution=MODEL_RESOLUTION,
+        device=DEVICE,
+        use_torch_upscale=USE_TORCH_UPSCALE,
+        max_train_resolution=MAX_TRAIN_RESOLUTION,
+    )

--- a/upscaler_torch.py
+++ b/upscaler_torch.py
@@ -1,0 +1,183 @@
+import torch
+
+
+"""
+Gradient-Aware Bicubic Spline Upscaling for 3D Gaussian Splatting
+
+Reference:
+  Niedermayr, S., Neuhauser, C., & Westermann, R. (2025).
+  "Lightweight Gradient-Aware Upscaling of 3D Gaussian Splatting Images"
+  arXiv:2503.14171v2 [cs.CV]
+  https://arxiv.org/abs/2503.14171
+
+OVERVIEW
+
+Bicubic spline interpolation using analytical image gradients from 3DGS rendering,
+rather than finite-difference approximations. The key insight is that 3DGS provides
+exact gradients ∂I/∂x, ∂I/∂y, ∂²I/∂x∂y at each pixel, enabling more accurate spline fitting.
+
+MATHEMATICAL FORMULATION
+
+BICUBIC SPLINE PARAMETERIZATION (Section G, Eq. 21):
+
+  p(x,y) = Σᵢ₌₀³ Σⱼ₌₀³ aᵢⱼ xⁱ yʲ
+
+The spline coefficients A ∈ ℝ⁴ˣ⁴ are computed by solving (Eq. 25-26):
+
+  F = C · A · Cᵀ
+  A = C⁻¹ · F · (Cᵀ)⁻¹
+
+where F is the constraint matrix containing function values and derivatives
+at the four corner points of the interpolation cell.
+
+F MATRIX LAYOUT (Eq. 6, 27):
+
+  F = [ f(0,0)    f(0,1)    fᵧ(0,0)   fᵧ(0,1)  ]
+      [ f(1,0)    f(1,1)    fᵧ(1,0)   fᵧ(1,1)  ]
+      [ fₓ(0,0)   fₓ(0,1)   fₓᵧ(0,0)  fₓᵧ(0,1) ]
+      [ fₓ(1,0)   fₓ(1,1)   fₓᵧ(1,0)  fₓᵧ(1,1) ]
+
+where:
+  f(i,j)    = pixel value at corner (i,j)
+  fₓ(i,j)   = ∂f/∂x at corner (i,j)  -- analytical gradient from 3DGS
+  fᵧ(i,j)   = ∂f/∂y at corner (i,j)  -- analytical gradient from 3DGS
+  fₓᵧ(i,j)  = ∂²f/∂x∂y at corner (i,j) -- mixed partial from 3DGS
+
+C MATRIX (Eq. 28):
+
+Derived from cubic polynomial constraints at x=0 and x=1:
+  f(x)  = a₀ + a₁x + a₂x² + a₃x³
+  f'(x) = a₁ + 2a₂x + 3a₃x²
+
+  C = [ 1  0  0  0 ]    (f(0)  = a₀)
+      [ 1  1  1  1 ]    (f(1)  = a₀ + a₁ + a₂ + a₃)
+      [ 0  1  0  0 ]    (f'(0) = a₁)
+      [ 0  1  2  3 ]    (f'(1) = a₁ + 2a₂ + 3a₃)
+
+  C⁻¹ = [  1   0   0   0 ]
+        [  0   0   1   0 ]
+        [ -3   3  -2  -1 ]
+        [  2  -2   1   1 ]
+
+POLYNOMIAL EVALUATION (Eq. 7):
+
+  p(x,y) = [1  x  x²  x³] · A · [1  y  y²  y³]ᵀ
+
+3DGS ANALYTICAL GRADIENTS (Section 5)
+
+The image I(x,y) from 3DGS is computed via alpha blending (Eq. 3):
+
+  I(x,y) = Σᵢ₌₁ᴺ Tᵢ(x,y) · αᵢ(x,y) · cᵢ
+
+Analytical gradients are computed during rendering (Eq. 8-10):
+
+  ∂I/∂x = Σᵢ cᵢ · (∂Tᵢ/∂x · αᵢ + Tᵢ · ∂αᵢ/∂x)
+
+  ∂I/∂y = Σᵢ cᵢ · (∂Tᵢ/∂y · αᵢ + Tᵢ · ∂αᵢ/∂y)
+
+  ∂²I/∂x∂y = Σᵢ cᵢ · (∂²Tᵢ/∂x∂y · αᵢ + ∂Tᵢ/∂x · ∂αᵢ/∂y
+                      + ∂Tᵢ/∂y · ∂αᵢ/∂x + Tᵢ · ∂²αᵢ/∂x∂y)
+
+These gradients are computed iteratively during the blending loop with
+minimal overhead, then passed to this upscaling kernel.
+
+IMPLEMENTATION NOTES
+
+- Forward: computes A = C⁻¹ · F · (C⁻¹)ᵀ, then evaluates p(tx,ty)
+- Memory layout: HWC format (height × width × channels)
+"""
+
+
+@torch.jit.script
+def torch_gradient_aware_upscale_single_channel(render: torch.Tensor, dx: torch.Tensor, dy: torch.Tensor, dxy: torch.Tensor, new_h: int, new_w: int):
+    """
+    Gradient aware spline interpolation for a single channel.
+    render, dx, dy, dxy: tensors of shape [H, W]
+    """
+    C = torch.tensor([
+        [1, 0, 0, 0],
+        [1, 1, 1, 1],
+        [0, 1, 0, 0],
+        [0, 1, 2, 3]
+    ], dtype=torch.float32, device="cuda:0")
+    C_inv = torch.inverse(C)
+
+    h, w = render.shape
+    device = render.device
+
+    y_coords = torch.linspace(0, h - 1, new_h, device=device)
+    x_coords = torch.linspace(0, w - 1, new_w, device=device)
+    grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing='ij')
+
+    y0 = torch.floor(grid_y).long()
+    x0 = torch.floor(grid_x).long()
+    y1 = torch.clamp(y0 + 1, 0, h - 1)
+    x1 = torch.clamp(x0 + 1, 0, w - 1)
+
+    ty = (grid_y - y0.float()).unsqueeze(-1)  # [new_h, new_w, 1]
+    tx = (grid_x - x0.float()).unsqueeze(-1)  # [new_h, new_w, 1]
+
+    y0 = torch.clamp(y0, 0, h - 1)
+    x0 = torch.clamp(x0, 0, w - 1)
+
+    f00 = render[y0, x0]  # [new_h, new_w]
+    f01 = render[y0, x1]
+    f10 = render[y1, x0]
+    f11 = render[y1, x1]
+
+    fx00 = dx[y0, x0]
+    fx01 = dx[y0, x1]
+    fx10 = dx[y1, x0]
+    fx11 = dx[y1, x1]
+
+    fy00 = dy[y0, x0]
+    fy01 = dy[y0, x1]
+    fy10 = dy[y1, x0]
+    fy11 = dy[y1, x1]
+
+    fxy00 = dxy[y0, x0]
+    fxy01 = dxy[y0, x1]
+    fxy10 = dxy[y1, x0]
+    fxy11 = dxy[y1, x1]
+
+    # F matrix: [new_h, new_w, 4, 4]
+    F = torch.stack([
+        torch.stack([f00, f10, fy00, fy10], dim=-1),
+        torch.stack([f01, f11, fy01, fy11], dim=-1),
+        torch.stack([fx00, fx10, fxy00, fxy10], dim=-1),
+        torch.stack([fx01, fx11, fxy01, fxy11], dim=-1)
+    ], dim=-2)
+
+    # A = C_inv @ F @ C_inv.T
+    F_reshaped = F.reshape(-1, 4, 4)
+    A = torch.matmul(torch.matmul(C_inv, F_reshaped), C_inv.t())
+    A = A.reshape(new_h, new_w, 4, 4)
+
+    # p(x,y) = px^T @ A @ py
+    ones = torch.ones_like(tx)
+    px_squeezed = torch.cat([ones, tx, tx ** 2, tx ** 3], dim=-1)  # [new_h, new_w, 4]
+    py_squeezed = torch.cat([ones, ty, ty ** 2, ty ** 3], dim=-1)  # [new_h, new_w, 4]
+
+    # Perform batched matrix multiplication
+    temp = torch.einsum('hwi,hwij->hwj', px_squeezed, A)  # [new_h, new_w, 4]
+    upscaled = torch.einsum('hwi,hwi->hw', temp, py_squeezed)  # [new_h, new_w]
+
+    return upscaled
+
+
+def torch_gradient_aware_upscale(render_hwc: torch.Tensor, dx: torch.Tensor, dy: torch.Tensor, dxy: torch.Tensor, new_h: int, new_w: int) -> torch.Tensor:
+    """
+    Bicubic spline interpolation for multi-channel image.
+    render_hwc, dx, dy, dxy: tensors of shape [H, W, C]
+    Returns: [new_h, new_w, C]
+    """
+    c = render_hwc.shape[2]
+    upscaled_channels = []
+    for ch in range(c):
+        upscaled_ch = torch_gradient_aware_upscale_single_channel(
+            render_hwc[..., ch], dx[..., ch], dy[..., ch], dxy[..., ch],
+            new_h, new_w
+        )
+        upscaled_channels.append(upscaled_ch)
+    
+    return torch.stack(upscaled_channels, dim=-1)


### PR DESCRIPTION
# Gradient-Aware Upscaling & SnugBox AABB for gsplat2d (+ optional Cholesky and Opacities)

## Summary

Implements gradient-aware bicubic spline upscaling from [Niedermayr et al. 2025](https://arxiv.org/abs/2503.14171) and SnugBox tight AABB from [Hanson et al. 2024](https://arxiv.org/abs/2412.00578) for 2D Gaussian splatting.

## Changes

### Gradient-Aware Upscaling
- CUDA kernel `gradient_aware_upscale_kernel` / `gradient_aware_upscale_backward_kernel` for bicubic spline interpolation using analytical gradients (dx, dy, dxy) from rasterization
- Forward rasterizer now optionaly computes per-pixel image gradients during alpha blending with minimal overhead
- PyTorch reference implementation in `upscaler_torch.py`
- Python bindings via `gradient_aware_upscale(render, dx, dy, dxy, dst_h, dst_w, roi)`

### SnugBox Tight AABB
- Replaces fixed 3-sigma radius with opacity-aware tight bounding box
- `radii: int` -> `extents: float2` (per-axis extent)
- `compute_cov2d_bounds()` now takes optional opacity and computes axis-aligned extent from ellipse threshold
- 1.5x-1.8x speedup even without opacities; larger gains with trainable opacities

### Cholesky Parametrization
- `project_gaussians_cholesky()` for direct covariance from lower triangular Cholesky factor [L11, L21, L22]
- Avoids explicit cov2d construction, cleaner gradients

### Separate Gaussian Opacities
- Rasterizer accepts optional `opacities` tensor (previously baked into alpha)
- Backward pass computes `v_opacity` when opacities provided

### Weighted Sum Output
- Rasterizer returns `out_wsum = Σ alpha_i` per pixel alongside rendered image
- Backward pass propagates gradients from `v_render_wsum` through to gaussian parameters (positions, conics, opacities)
- Enables transparency-based losses (e.g. penalizing total alpha to encourage sparse coverage, or regularizing opacity distribution)
